### PR TITLE
feat: ECS Fargate seed runner for AWS database seeding

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -25,6 +25,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
       - name: Install Pulumi dependencies
         run: npm install
         working-directory: pulumi

--- a/docker/Dockerfile.seed
+++ b/docker/Dockerfile.seed
@@ -2,15 +2,16 @@ FROM node:24-alpine
 RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
 WORKDIR /workspace
 COPY package.json pnpm-lock.yaml tsconfig.base.json nx.json jest.preset.js ./
-RUN pnpm install --frozen-lockfile --ignore-scripts
+RUN pnpm install --frozen-lockfile --ignore-scripts && \
+    pnpm add -g tsx
 COPY services/search-service/      ./services/search-service/
 COPY services/inventory-service/   ./services/inventory-service/
 COPY services/integration-service/ ./services/integration-service/
 CMD ["sh", "-c", "\
   cd /workspace/services/search-service && DATABASE_URL=$SEARCH_DB_URL /workspace/node_modules/.bin/kysely migrate:latest && \
-  cd /workspace && DATABASE_URL=$SEARCH_DB_URL /workspace/node_modules/.bin/tsx services/search-service/scripts/seed.ts && \
+  cd /workspace && DATABASE_URL=$SEARCH_DB_URL tsx services/search-service/scripts/seed.ts && \
   cd /workspace/services/inventory-service && DATABASE_URL=$INVENTORY_DB_URL /workspace/node_modules/.bin/kysely migrate:latest && \
-  cd /workspace && DATABASE_URL=$INVENTORY_DB_URL /workspace/node_modules/.bin/tsx services/inventory-service/scripts/seed.ts && \
+  cd /workspace && DATABASE_URL=$INVENTORY_DB_URL tsx services/inventory-service/scripts/seed.ts && \
   cd /workspace/services/integration-service && DATABASE_URL=$INTEGRATION_DB_URL /workspace/node_modules/.bin/kysely migrate:latest && \
-  cd /workspace && DATABASE_URL=$INTEGRATION_DB_URL /workspace/node_modules/.bin/tsx services/integration-service/scripts/seed.ts \
+  cd /workspace && DATABASE_URL=$INTEGRATION_DB_URL tsx services/integration-service/scripts/seed.ts \
 "]

--- a/docker/Dockerfile.seed
+++ b/docker/Dockerfile.seed
@@ -7,10 +7,10 @@ COPY services/search-service/      ./services/search-service/
 COPY services/inventory-service/   ./services/inventory-service/
 COPY services/integration-service/ ./services/integration-service/
 CMD ["sh", "-c", "\
-  cd /workspace/services/search-service && DATABASE_URL=$SEARCH_DB_URL pnpm exec kysely migrate:latest && \
-  cd /workspace && DATABASE_URL=$SEARCH_DB_URL npx tsx services/search-service/scripts/seed.ts && \
-  cd /workspace/services/inventory-service && DATABASE_URL=$INVENTORY_DB_URL pnpm exec kysely migrate:latest && \
-  cd /workspace && DATABASE_URL=$INVENTORY_DB_URL npx tsx services/inventory-service/scripts/seed.ts && \
-  cd /workspace/services/integration-service && DATABASE_URL=$INTEGRATION_DB_URL pnpm exec kysely migrate:latest && \
-  cd /workspace && DATABASE_URL=$INTEGRATION_DB_URL npx tsx services/integration-service/scripts/seed.ts \
+  cd /workspace/services/search-service && DATABASE_URL=$SEARCH_DB_URL /workspace/node_modules/.bin/kysely migrate:latest && \
+  cd /workspace && DATABASE_URL=$SEARCH_DB_URL /workspace/node_modules/.bin/tsx services/search-service/scripts/seed.ts && \
+  cd /workspace/services/inventory-service && DATABASE_URL=$INVENTORY_DB_URL /workspace/node_modules/.bin/kysely migrate:latest && \
+  cd /workspace && DATABASE_URL=$INVENTORY_DB_URL /workspace/node_modules/.bin/tsx services/inventory-service/scripts/seed.ts && \
+  cd /workspace/services/integration-service && DATABASE_URL=$INTEGRATION_DB_URL /workspace/node_modules/.bin/kysely migrate:latest && \
+  cd /workspace && DATABASE_URL=$INTEGRATION_DB_URL /workspace/node_modules/.bin/tsx services/integration-service/scripts/seed.ts \
 "]

--- a/docker/Dockerfile.seed
+++ b/docker/Dockerfile.seed
@@ -3,7 +3,7 @@ RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
 WORKDIR /workspace
 COPY package.json pnpm-lock.yaml tsconfig.base.json nx.json jest.preset.js ./
 RUN pnpm install --frozen-lockfile --ignore-scripts && \
-    pnpm add -g tsx
+    npm install -g tsx
 COPY services/search-service/      ./services/search-service/
 COPY services/inventory-service/   ./services/inventory-service/
 COPY services/integration-service/ ./services/integration-service/

--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -476,9 +476,10 @@ const seedTaskDef = new aws.ecs.TaskDefinition("seed-task", {
       image,
       essential: true,
       environment: [
-        { name: "SEARCH_DB_URL",      value: `postgres://travelhub:${pass}@${host}:5432/search?sslmode=require` },
-        { name: "INVENTORY_DB_URL",   value: `postgres://travelhub:${pass}@${host}:5432/inventory?sslmode=require` },
-        { name: "INTEGRATION_DB_URL", value: `postgres://travelhub:${pass}@${host}:5432/integration_service?sslmode=require` },
+        { name: "SEARCH_DB_URL",                   value: `postgres://travelhub:${pass}@${host}:5432/search?sslmode=require` },
+        { name: "INVENTORY_DB_URL",                value: `postgres://travelhub:${pass}@${host}:5432/inventory?sslmode=require` },
+        { name: "INTEGRATION_DB_URL",              value: `postgres://travelhub:${pass}@${host}:5432/integration_service?sslmode=require` },
+        { name: "NODE_TLS_REJECT_UNAUTHORIZED",    value: "0" },
       ],
       logConfiguration: {
         logDriver: "awslogs",

--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -476,9 +476,9 @@ const seedTaskDef = new aws.ecs.TaskDefinition("seed-task", {
       image,
       essential: true,
       environment: [
-        { name: "SEARCH_DB_URL",      value: `postgres://travelhub:${pass}@${host}:5432/search` },
-        { name: "INVENTORY_DB_URL",   value: `postgres://travelhub:${pass}@${host}:5432/inventory` },
-        { name: "INTEGRATION_DB_URL", value: `postgres://travelhub:${pass}@${host}:5432/integration_service` },
+        { name: "SEARCH_DB_URL",      value: `postgres://travelhub:${pass}@${host}:5432/search?sslmode=require` },
+        { name: "INVENTORY_DB_URL",   value: `postgres://travelhub:${pass}@${host}:5432/inventory?sslmode=require` },
+        { name: "INTEGRATION_DB_URL", value: `postgres://travelhub:${pass}@${host}:5432/integration_service?sslmode=require` },
       ],
       logConfiguration: {
         logDriver: "awslogs",

--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -451,6 +451,17 @@ new aws.iam.RolePolicyAttachment("ecs-exec-policy", {
   role:      ecsExecRole.name,
   policyArn: "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
 });
+new aws.iam.RolePolicy("ecs-exec-logs-policy", {
+  role: ecsExecRole.name,
+  policy: JSON.stringify({
+    Version: "2012-10-17",
+    Statement: [{
+      Effect:   "Allow",
+      Action:   ["logs:CreateLogGroup"],
+      Resource: "arn:aws:logs:us-east-1:*:log-group:/ecs/travelhub-seed*",
+    }],
+  }),
+});
 
 const seedTaskDef = new aws.ecs.TaskDefinition("seed-task", {
   family:                  "travelhub-seed",


### PR DESCRIPTION
## Summary

- Adds `docker/Dockerfile.seed` — single-stage image that installs full monorepo deps and runs migrate + seed for search, inventory, and integration services directly (bypassing `nx run` to avoid the hardcoded `DATABASE_URL` in `integration-service/project.json`)
- Adds ECS Fargate infrastructure to `pulumi/index.ts` — ECR repo, seed image, ECS cluster, IAM execution role with `logs:CreateLogGroup` inline policy, and task definition with per-service DB URLs and `NODE_TLS_REJECT_UNAUTHORIZED=0` for RDS SSL; logs to CloudWatch `/ecs/travelhub-seed`
- Adds `.github/workflows/seed.yml` — manually triggered workflow that reads stack outputs, launches the Fargate task on private subnets using the existing `appRunnerSg`, waits for completion, and asserts exit code 0

## How it works

1. Run `pulumi up` to provision the ECS resources and push the seed image to ECR
2. Trigger **Seed Databases** from GitHub Actions → Actions tab
3. Fargate task runs inside the VPC, connects to private RDS, truncates and reseeds search + inventory tables, idempotently inserts integration fixtures

## Notes

- Search and inventory seeds **truncate all rows** before reinserting — do not run against a database with live data you want to keep
- Integration seed uses `INSERT … ON CONFLICT DO NOTHING` — safe to run multiple times
- The ECS cluster costs $0 when idle; Fargate compute is billed only while the task runs (~$0.001 per seed run)

## Test plan

- [ ] `pulumi preview` shows new resources: ECR repo, ECS cluster, IAM role, task definition
- [ ] After `pulumi up`, confirm `seedClusterArn` and `seedTaskDefinitionArn` in stack outputs
- [ ] Trigger seed workflow manually — "Assert exit code 0" step passes
- [ ] CloudWatch logs at `/ecs/travelhub-seed` show inserts for all three services
- [ ] Search API returns seeded properties

🤖 Generated with [Claude Code](https://claude.com/claude-code)