### PR TITLE
feat(taxes-fees): implementar impuestos y tarifas de socios en búsqueda

### DIFF
--- a/.github/workflows/seed.yml
+++ b/.github/workflows/seed.yml
@@ -79,6 +79,7 @@ jobs:
 
           DATABASE_URL="${BASE}/search"              pnpm exec nx run search-service:migrate
           DATABASE_URL="${BASE}/inventory"           pnpm exec nx run inventory-service:migrate
+          DATABASE_URL="${BASE}/booking"             pnpm exec nx run booking-service:migrate
           DATABASE_URL="${BASE}/integration_service" pnpm exec nx run integration-service:migrate
 
       # Seed only the services that ship seed data
@@ -88,4 +89,5 @@ jobs:
 
           DATABASE_URL="${BASE}/search"              pnpm exec nx run search-service:seed
           DATABASE_URL="${BASE}/inventory"           pnpm exec nx run inventory-service:seed
+          DATABASE_URL="${BASE}/booking"             pnpm exec nx run booking-service:seed
           DATABASE_URL="${BASE}/integration_service" pnpm exec nx run integration-service:seed

--- a/frontend/src/App.spec.tsx
+++ b/frontend/src/App.spec.tsx
@@ -7,19 +7,28 @@ import en from './i18n/locales/en.json';
 const i18n = setupTestI18n('es');
 
 const mockProperty = (id: string, name: string) => ({
-  id,
-  name,
-  city: 'Cancún',
-  countryCode: 'MX',
-  neighborhood: 'Zona Hotelera',
-  lat: 21.16,
-  lon: -86.85,
-  stars: 5,
-  rating: 4.7,
-  reviewCount: 100,
-  thumbnailUrl: 'https://placehold.co/400x300',
-  amenities: ['wifi'],
-  bestRoom: { roomId: 'r1', roomType: 'deluxe', bedType: 'king', capacity: 2, basePriceUsd: 300, priceUsd: 300 },
+  roomId: 'r1',
+  roomType: 'deluxe',
+  bedType: 'king',
+  viewType: 'ocean',
+  capacity: 2,
+  basePriceUsd: 300,
+  priceUsd: 300,
+  taxRatePct: 16,
+  estimatedTotalUsd: 348,
+  hasFlatFees: false,
+  property: {
+    id,
+    name,
+    city: 'Cancún',
+    countryCode: 'MX',
+    neighborhood: 'Zona Hotelera',
+    stars: 5,
+    rating: 4.7,
+    reviewCount: 100,
+    thumbnailUrl: 'https://placehold.co/400x300',
+    amenities: ['wifi'],
+  },
 });
 
 const featuredResponse = {

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -39,13 +39,13 @@ export default function HomePage() {
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-6">
           {featured.map((result) => (
             <HotelCard
-              key={result.id}
-              id={result.id}
-              name={result.name}
-              location={formatAddress(result.neighborhood, result.city, result.countryCode)}
-              price={result.bestRoom.basePriceUsd}
-              img={result.thumbnailUrl}
-              onClick={() => navigate({ to: '/properties/$propertyId', params: { propertyId: result.id }, search: { checkIn: todayISO(), checkOut: offsetDateISO(2), guests: 2 } })}
+              key={result.property.id}
+              id={result.property.id}
+              name={result.property.name}
+              location={formatAddress(result.property.neighborhood, result.property.city, result.property.countryCode)}
+              price={result.basePriceUsd}
+              img={result.property.thumbnailUrl}
+              onClick={() => navigate({ to: '/properties/$propertyId', params: { propertyId: result.property.id }, search: { checkIn: todayISO(), checkOut: offsetDateISO(2), guests: 2 } })}
             />
           ))}
         </div>

--- a/frontend/src/pages/PropertyDetailPage.spec.tsx
+++ b/frontend/src/pages/PropertyDetailPage.spec.tsx
@@ -16,8 +16,6 @@ const mockProperty = {
   city: 'Bogotá',
   countryCode: 'CO',
   neighborhood: 'Chapinero',
-  lat: 4.65,
-  lon: -74.05,
   stars: 4,
   rating: 4.5,
   reviewCount: 120,
@@ -27,25 +25,23 @@ const mockProperty = {
 
 const mockRooms = [
   {
-    id: 'r1',
-    propertyId: 'prop_001',
+    roomId: 'r1',
     roomType: 'suite',
     bedType: 'king',
     viewType: 'city',
     capacity: 2,
-    totalRooms: 5,
-    basePriceUsd: '150.00',
-    status: 'active',
+    basePriceUsd: 150,
+    priceUsd: 130,
+    taxRatePct: 16,
+    estimatedTotalUsd: 1205.6,
+    hasFlatFees: false,
   },
 ];
 
-function mockFetch(propertyOk = true, rooms = mockRooms) {
-  (global.fetch as jest.Mock).mockImplementation((url: string) => {
-    if (url.includes('/rooms')) {
-      return Promise.resolve({ ok: true, json: () => Promise.resolve(rooms) });
-    }
-    if (!propertyOk) return Promise.resolve({ ok: false });
-    return Promise.resolve({ ok: true, json: () => Promise.resolve(mockProperty) });
+function mockFetch(ok = true, rooms = mockRooms, property = mockProperty) {
+  (global.fetch as jest.Mock).mockResolvedValue({
+    ok,
+    json: () => Promise.resolve({ property: ok ? property : null, rooms: ok ? rooms : [] }),
   });
 }
 
@@ -84,6 +80,22 @@ describe('PropertyDetailPage', () => {
     expect(await screen.findByText(es.property_detail.loading)).toBeInTheDocument();
   });
 
+  it('calls the search rooms endpoint with propertyId', async () => {
+    mockFetch();
+    renderPage('prop_001');
+    await screen.findByText('Hotel Test');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/api/search/properties/prop_001/rooms'),
+    );
+  });
+
+  it('makes only one fetch call', async () => {
+    mockFetch();
+    renderPage();
+    await screen.findByText('Hotel Test');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
   it('shows property details after successful fetch', async () => {
     mockFetch();
     renderPage();
@@ -94,7 +106,16 @@ describe('PropertyDetailPage', () => {
   });
 
   it('shows error state when fetch fails', async () => {
-    mockFetch(false);
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: false });
+    renderPage();
+    expect(await screen.findByText(es.property_detail.error)).toBeInTheDocument();
+  });
+
+  it('shows error state when property is null', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ property: null, rooms: [] }),
+    });
     renderPage();
     expect(await screen.findByText(es.property_detail.error)).toBeInTheDocument();
   });
@@ -109,5 +130,18 @@ describe('PropertyDetailPage', () => {
     mockFetch();
     renderPage();
     expect(await screen.findByText('Reservar')).toBeInTheDocument();
+  });
+
+  it('renders room type label', async () => {
+    mockFetch();
+    renderPage();
+    expect(await screen.findByText('Suite')).toBeInTheDocument();
+  });
+
+  it('shows estimatedTotalUsd as the total price (taxes included)', async () => {
+    mockFetch();
+    renderPage();
+    // estimatedTotalUsd = 1205.6 → formatted; label must include taxes note
+    expect(await screen.findByText(/impuestos incl\./)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/PropertyDetailPage.tsx
+++ b/frontend/src/pages/PropertyDetailPage.tsx
@@ -19,19 +19,20 @@ import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 
-interface Room {
-  id: string;
-  propertyId: string;
+interface SearchRoom {
+  roomId: string;
   roomType: string;
   bedType: string;
   viewType: string;
   capacity: number;
-  totalRooms: number;
-  basePriceUsd: string;
-  status: string;
+  basePriceUsd: number;
+  priceUsd: number | null;
+  taxRatePct: number;
+  estimatedTotalUsd: number;
+  hasFlatFees: boolean;
 }
 
-interface PropertyDetail {
+interface PropertyInfo {
   id: string;
   name: string;
   city: string;
@@ -44,28 +45,27 @@ interface PropertyDetail {
   amenities: string[];
 }
 
-async function fetchProperty(propertyId: string): Promise<PropertyDetail> {
-  const res = await fetch(`${API_BASE}/api/inventory/properties/${propertyId}`);
-  if (!res.ok) throw new Error(`Failed to fetch property ${propertyId}`);
-  return res.json() as Promise<PropertyDetail>;
+interface PropertyRoomsResponse {
+  property: PropertyInfo | null;
+  rooms: SearchRoom[];
 }
 
-async function fetchRooms(propertyId: string): Promise<Room[]> {
-  const res = await fetch(`${API_BASE}/api/inventory/rooms?propertyId=${encodeURIComponent(propertyId)}`);
+async function fetchPropertyRooms(
+  propertyId: string,
+  checkIn?: string,
+  checkOut?: string,
+  guests?: number,
+): Promise<PropertyRoomsResponse> {
+  const params = new URLSearchParams();
+  if (checkIn) params.set('checkIn', checkIn);
+  if (checkOut) params.set('checkOut', checkOut);
+  if (guests) params.set('guests', String(guests));
+  const qs = params.toString();
+  const res = await fetch(
+    `${API_BASE}/api/search/properties/${propertyId}/rooms${qs ? `?${qs}` : ''}`,
+  );
   if (!res.ok) throw new Error(`Failed to fetch rooms for property ${propertyId}`);
-  return res.json() as Promise<Room[]>;
-}
-
-async function fetchAvailability(
-  roomIds: string[],
-  fromDate: string,
-  toDate: string,
-): Promise<Set<string>> {
-  const params = new URLSearchParams({ roomId: roomIds.join(','), fromDate, toDate });
-  const res = await fetch(`${API_BASE}/api/inventory/availability?${params}`);
-  if (!res.ok) throw new Error('Failed to fetch availability');
-  const data: { roomId: string; available: boolean }[] = await res.json();
-  return new Set(data.filter((r) => r.available).map((r) => r.roomId));
+  return res.json() as Promise<PropertyRoomsResponse>;
 }
 
 const AMENITY_LABELS: Record<string, string> = {
@@ -105,29 +105,14 @@ export default function PropertyDetailPage() {
   const [checkOut, setCheckOut] = useState<Dayjs | null>(qCheckOut ? dayjs(qCheckOut) : dayjs().add(8, 'day'));
   const [guests, setGuests] = useState<number>(qGuests > 0 ? qGuests : 1);
 
-  const { data, isPending, isError } = useQuery<PropertyDetail>({
-    queryKey: ['property', propertyId],
-    queryFn: () => fetchProperty(propertyId),
-  });
-
-  const { data: rooms = [], isPending: roomsPending } = useQuery<Room[]>({
-    queryKey: ['property-rooms', propertyId],
-    queryFn: () => fetchRooms(propertyId),
-  });
-
   const fromDate = checkIn?.format('YYYY-MM-DD');
   const toDate = checkOut?.format('YYYY-MM-DD');
-  const canCheckAvailability = rooms.length > 0 && !!fromDate && !!toDate;
+  const nights = checkOut && checkIn ? Math.max(1, checkOut.diff(checkIn, 'day')) : 1;
 
-  const { data: availableIds, isPending: availPending } = useQuery<Set<string>>({
-    queryKey: ['room-availability', propertyId, fromDate, toDate],
-    queryFn: () => fetchAvailability(rooms.map((r) => r.id), fromDate!, toDate!),
-    enabled: canCheckAvailability,
+  const { data, isPending, isError } = useQuery<PropertyRoomsResponse>({
+    queryKey: ['property-rooms', propertyId, fromDate, toDate, guests],
+    queryFn: () => fetchPropertyRooms(propertyId, fromDate, toDate, guests),
   });
-
-  const visibleRooms = canCheckAvailability && availableIds
-    ? rooms.filter((r) => availableIds.has(r.id))
-    : rooms;
 
   if (isPending) {
     return (
@@ -137,7 +122,7 @@ export default function PropertyDetailPage() {
     );
   }
 
-  if (isError || !data) {
+  if (isError || !data?.property) {
     return (
       <main className="flex-1 max-w-6xl mx-auto w-full px-6 py-10">
         <p className="text-red-500">{t('property_detail.error')}</p>
@@ -145,7 +130,8 @@ export default function PropertyDetailPage() {
     );
   }
 
-  const address = formatAddress(data.neighborhood, data.city, data.countryCode);
+  const { property, rooms } = data;
+  const address = formatAddress(property.neighborhood, property.city, property.countryCode);
 
   return (
     <main className="flex-1 max-w-6xl mx-auto w-full px-6 py-8">
@@ -166,14 +152,14 @@ export default function PropertyDetailPage() {
       {/* Image gallery */}
       <div className="grid grid-cols-3 gap-2 rounded-2xl overflow-hidden mb-6 h-64">
         {[0, 1, 2].map((i) => (
-          <img key={i} src={data.thumbnailUrl} alt={data.name} className="w-full h-full object-cover" />
+          <img key={i} src={property.thumbnailUrl} alt={property.name} className="w-full h-full object-cover" />
         ))}
       </div>
 
       {/* Property header */}
       <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900 uppercase mb-1">{data.name}</h1>
+          <h1 className="text-2xl font-bold text-gray-900 uppercase mb-1">{property.name}</h1>
           <p className="text-gray-500 text-sm">{address}</p>
         </div>
         <Button
@@ -190,16 +176,16 @@ export default function PropertyDetailPage() {
       <section className="mb-6">
         <h2 className="text-base font-bold text-gray-900 mb-2">Acerca del hotel</h2>
         <p className="text-gray-600 text-sm leading-relaxed">
-          {data.name} está ubicado en {address}. Ofrece instalaciones de primera clase y un servicio excepcional para garantizar la comodidad de sus huéspedes durante toda su estadía.
+          {property.name} está ubicado en {address}. Ofrece instalaciones de primera clase y un servicio excepcional para garantizar la comodidad de sus huéspedes durante toda su estadía.
         </p>
       </section>
 
       {/* Amenities */}
-      {data.amenities.length > 0 && (
+      {property.amenities.length > 0 && (
         <section className="mb-8">
           <h2 className="text-base font-bold text-gray-900 mb-3">{t('property_detail.amenities')}</h2>
           <div className="flex flex-wrap gap-2">
-            {data.amenities.map((amenity) => (
+            {property.amenities.map((amenity) => (
               <Chip
                 key={amenity}
                 label={AMENITY_LABELS[amenity] ?? amenity}
@@ -216,7 +202,7 @@ export default function PropertyDetailPage() {
         <div className="flex items-baseline justify-between mb-4">
           <h2 className="text-xl font-bold text-gray-900">{t('property_detail.rooms')}</h2>
           <p className="text-sm text-gray-500">
-            <span className="font-bold text-gray-900">{visibleRooms.length} habitaciones</span> disponibles encontradas
+            <span className="font-bold text-gray-900">{rooms.length} habitaciones</span> disponibles encontradas
           </p>
         </div>
 
@@ -274,21 +260,16 @@ export default function PropertyDetailPage() {
 
           {/* Room list */}
           <div className="flex-1 flex flex-col gap-4">
-            {(roomsPending || (canCheckAvailability && availPending)) && (
-              <p className="text-gray-400 text-sm">Cargando habitaciones...</p>
-            )}
-            {visibleRooms.map((room) => {
-              const pricePerNight = parseFloat(room.basePriceUsd);
-              const nights = checkOut && checkIn ? Math.max(1, checkOut.diff(checkIn, 'day')) : 1;
-              const totalPrice = pricePerNight * nights;
+            {rooms.map((room) => {
+              const pricePerNight = room.priceUsd ?? room.basePriceUsd;
               const roomLabel = ROOM_TYPE_LABELS[room.roomType] ?? room.roomType;
               const bedLabel = BED_TYPE_LABELS[room.bedType] ?? room.bedType;
 
               return (
-                <Card key={room.id} variant="outlined" sx={{ display: 'flex', borderRadius: 3, overflow: 'hidden', bgcolor: 'grey.50' }}>
+                <Card key={room.roomId} variant="outlined" sx={{ display: 'flex', borderRadius: 3, overflow: 'hidden', bgcolor: 'grey.50' }}>
                   <CardMedia
                     component="img"
-                    image={data.thumbnailUrl}
+                    image={property.thumbnailUrl}
                     alt={roomLabel}
                     sx={{ width: 220, flexShrink: 0, objectFit: 'cover', alignSelf: 'stretch' }}
                   />
@@ -321,6 +302,11 @@ export default function PropertyDetailPage() {
                       <Typography component="span" variant="body2" color="text.secondary" fontWeight={400}>
                         {t('property_detail.per_night')}
                       </Typography>
+                      {room.hasFlatFees && (
+                        <Typography component="span" variant="body2" color="text.secondary" fontWeight={400}>
+                          {' '}· tarifas incluidas
+                        </Typography>
+                      )}
                     </Typography>
                   </CardContent>
                   <Box
@@ -336,10 +322,10 @@ export default function PropertyDetailPage() {
                   >
                     <Box textAlign="right">
                       <Typography variant="h5" fontWeight={700} lineHeight={1.2}>
-                        {formatPrice(totalPrice, currency)}
+                        {formatPrice(room.estimatedTotalUsd, currency)}
                       </Typography>
                       <Typography variant="body2" color="text.secondary">
-                        por {nights} noches
+                        por {nights} noches · impuestos incl.
                       </Typography>
                     </Box>
                     <Button

--- a/frontend/src/pages/search/ResultCard.spec.tsx
+++ b/frontend/src/pages/search/ResultCard.spec.tsx
@@ -15,30 +15,35 @@ function renderCard(ui: React.ReactElement) {
 const amenityLabels = { wifi: 'WiFi', pool: 'Piscina', spa: 'Spa', gym: 'Gimnasio' };
 const roomTypeLabels = { suite: 'Suite', standard: 'Estándar', deluxe: 'Deluxe' };
 
-function makeResult(overrides: Partial<SearchResult> = {}): SearchResult {
+function makeResult(
+  overrides: Partial<Omit<SearchResult, 'property'>> & { property?: Partial<SearchResult['property']> } = {},
+): SearchResult {
+  const { property: propertyOverrides, ...roomOverrides } = overrides;
   return {
-    id: 'p1',
-    name: 'Gran Caribe Resort',
-    city: 'Cancún',
-    countryCode: 'MX',
-    neighborhood: 'Zona Hotelera',
-    thumbnailUrl: 'https://placehold.co/400x300',
-    amenities: ['wifi', 'pool', 'spa', 'gym'],
-    stars: 5,
-    rating: 4.7,
-    reviewCount: 842,
-    bestRoom: {
-      roomId: 'r1',
-      roomType: 'suite',
-      bedType: 'king',
-      capacity: 2,
-      basePriceUsd: 320,
-      priceUsd: 280,
-      taxRatePct: 16,
-      estimatedTotalUsd: 1300,
-      hasFlatFees: false,
+    roomId: 'r1',
+    roomType: 'suite',
+    bedType: 'king',
+    viewType: 'city',
+    capacity: 2,
+    basePriceUsd: 320,
+    priceUsd: 280,
+    taxRatePct: 16,
+    estimatedTotalUsd: 1300,
+    hasFlatFees: false,
+    ...roomOverrides,
+    property: {
+      id: 'p1',
+      name: 'Gran Caribe Resort',
+      city: 'Cancún',
+      countryCode: 'MX',
+      neighborhood: 'Zona Hotelera',
+      thumbnailUrl: 'https://placehold.co/400x300',
+      amenities: ['wifi', 'pool', 'spa', 'gym'],
+      stars: 5,
+      rating: 4.7,
+      reviewCount: 842,
+      ...propertyOverrides,
     },
-    ...overrides,
   };
 }
 
@@ -73,7 +78,7 @@ describe('ResultCard', () => {
   it('renders neighborhood when present', () => {
     renderCard(
       <ResultCard
-        result={makeResult({ neighborhood: 'Zona Hotelera' })}
+        result={makeResult({ property: { neighborhood: 'Zona Hotelera' } })}
         nights={4}
         amenityLabels={amenityLabels}
         roomTypeLabels={roomTypeLabels}
@@ -101,13 +106,7 @@ describe('ResultCard', () => {
     // estimatedTotalUsd=1300, 1300*4200=5,460,000 COP — look for "460"
     renderCard(
       <ResultCard
-        result={makeResult({
-          bestRoom: {
-            roomId: 'r1', roomType: 'suite', bedType: 'king', capacity: 2,
-            basePriceUsd: 320, priceUsd: null,
-            taxRatePct: 16, estimatedTotalUsd: 1300, hasFlatFees: false,
-          },
-        })}
+        result={makeResult({ priceUsd: null })}
         nights={3}
         amenityLabels={amenityLabels}
         roomTypeLabels={roomTypeLabels}
@@ -146,13 +145,7 @@ describe('ResultCard', () => {
   it('shows flat fees disclaimer when hasFlatFees=true and nights > 0', () => {
     renderCard(
       <ResultCard
-        result={makeResult({
-          bestRoom: {
-            roomId: 'r1', roomType: 'suite', bedType: 'king', capacity: 2,
-            basePriceUsd: 320, priceUsd: 280,
-            taxRatePct: 16, estimatedTotalUsd: 1350, hasFlatFees: true,
-          },
-        })}
+        result={makeResult({ estimatedTotalUsd: 1350, hasFlatFees: true })}
         nights={4}
         amenityLabels={amenityLabels}
         roomTypeLabels={roomTypeLabels}
@@ -165,7 +158,7 @@ describe('ResultCard', () => {
   it('does not show flat fees disclaimer when hasFlatFees=false', () => {
     renderCard(
       <ResultCard
-        result={makeResult({ bestRoom: { roomId: 'r1', roomType: 'suite', bedType: 'king', capacity: 2, basePriceUsd: 320, priceUsd: 280, taxRatePct: 16, estimatedTotalUsd: 1300, hasFlatFees: false } })}
+        result={makeResult({ hasFlatFees: false })}
         nights={4}
         amenityLabels={amenityLabels}
         roomTypeLabels={roomTypeLabels}
@@ -192,7 +185,7 @@ describe('ResultCard', () => {
   it('shows at most 3 amenities', () => {
     renderCard(
       <ResultCard
-        result={makeResult({ amenities: ['wifi', 'pool', 'spa', 'gym'] })}
+        result={makeResult({ property: { amenities: ['wifi', 'pool', 'spa', 'gym'] } })}
         nights={2}
         amenityLabels={amenityLabels}
         roomTypeLabels={roomTypeLabels}
@@ -208,7 +201,7 @@ describe('ResultCard', () => {
   it('resolves amenity labels via the label map', () => {
     renderCard(
       <ResultCard
-        result={makeResult({ amenities: ['pool'] })}
+        result={makeResult({ property: { amenities: ['pool'] } })}
         nights={2}
         amenityLabels={amenityLabels}
         roomTypeLabels={roomTypeLabels}
@@ -221,7 +214,7 @@ describe('ResultCard', () => {
   it('falls back to code when amenity label is not in map', () => {
     renderCard(
       <ResultCard
-        result={makeResult({ amenities: ['beach_access'] })}
+        result={makeResult({ property: { amenities: ['beach_access'] } })}
         nights={2}
         amenityLabels={amenityLabels}
         roomTypeLabels={roomTypeLabels}

--- a/frontend/src/pages/search/ResultCard.tsx
+++ b/frontend/src/pages/search/ResultCard.tsx
@@ -29,12 +29,12 @@ export default function ResultCard({
 }: ResultCardProps) {
   const { t } = useTranslation();
   const { currency } = useLocale();
-  const { estimatedTotalUsd, hasFlatFees } = result.bestRoom;
+  const { estimatedTotalUsd, hasFlatFees } = result;
   const nightsLabel = t('search.card.nights', { count: nights || 1 });
   const inclLabel = hasFlatFees
     ? t('search.card.incl_taxes_fees')
     : t('search.card.incl_taxes_only');
-  const topAmenities = result.amenities.slice(0, 3);
+  const topAmenities = result.property.amenities.slice(0, 3);
 
   return (
     <Card
@@ -43,8 +43,8 @@ export default function ResultCard({
     >
       <CardMedia
         component="img"
-        image={result.thumbnailUrl || 'https://placehold.co/224x170?text=Hotel'}
-        alt={result.name}
+        image={result.property.thumbnailUrl || 'https://placehold.co/224x170?text=Hotel'}
+        alt={result.property.name}
         sx={{ width: '27%', flexShrink: 0, objectFit: 'cover' }}
         onError={(e) => {
           (e.currentTarget as HTMLImageElement).src = 'https://placehold.co/224x170?text=Hotel';
@@ -73,14 +73,14 @@ export default function ResultCard({
             noWrap
             color="text.primary"
           >
-            {result.name}
+            {result.property.name}
           </Typography>
           <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
-            {formatAddress(result.neighborhood, result.city, result.countryCode)}
+            {formatAddress(result.property.neighborhood, result.property.city, result.property.countryCode)}
           </Typography>
           <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
-            {resolveLabel(roomTypeLabels, result.bestRoom.roomType)} · {result.bestRoom.capacity}{' '}
-            {t('search.card.guests', { count: result.bestRoom.capacity })}
+            {resolveLabel(roomTypeLabels, result.roomType)} · {result.capacity}{' '}
+            {t('search.card.guests', { count: result.capacity })}
           </Typography>
         </Box>
         <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>

--- a/frontend/src/pages/search/SearchPage.spec.tsx
+++ b/frontend/src/pages/search/SearchPage.spec.tsx
@@ -22,17 +22,28 @@ jest.mock('@tanstack/react-router', () => ({
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
 const mockSearchResult = {
-  id: 'p1',
-  name: 'Gran Caribe Resort',
-  city: 'Cancún',
-  countryCode: 'MX',
-  neighborhood: 'Zona Hotelera',
-  thumbnailUrl: 'https://placehold.co/400x300',
-  amenities: ['wifi', 'pool'],
-  stars: 5,
-  rating: 4.7,
-  reviewCount: 842,
-  bestRoom: { roomId: 'r1', roomType: 'suite', bedType: 'king', capacity: 2, basePriceUsd: 320, priceUsd: 280 },
+  roomId: 'r1',
+  roomType: 'suite',
+  bedType: 'king',
+  viewType: 'city',
+  capacity: 2,
+  basePriceUsd: 320,
+  priceUsd: 280,
+  taxRatePct: 16,
+  estimatedTotalUsd: 1300,
+  hasFlatFees: false,
+  property: {
+    id: 'p1',
+    name: 'Gran Caribe Resort',
+    city: 'Cancún',
+    countryCode: 'MX',
+    neighborhood: 'Zona Hotelera',
+    thumbnailUrl: 'https://placehold.co/400x300',
+    amenities: ['wifi', 'pool'],
+    stars: 5,
+    rating: 4.7,
+    reviewCount: 842,
+  },
 };
 
 const mockSearchResponse = {

--- a/frontend/src/pages/search/index.tsx
+++ b/frontend/src/pages/search/index.tsx
@@ -169,7 +169,7 @@ export default function SearchPage() {
 
           {results.map((result) => (
             <ResultCard
-              key={result.id}
+              key={result.roomId}
               result={result}
               nights={nights}
               amenityLabels={amenityLabels}
@@ -177,7 +177,7 @@ export default function SearchPage() {
               onBook={() =>
                 navigate({
                   to: '/properties/$propertyId',
-                  params: { propertyId: result.id },
+                  params: { propertyId: result.property.id },
                   search: {
                     checkIn: urlCheckIn,
                     checkOut: urlCheckOut,

--- a/frontend/src/pages/search/types.ts
+++ b/frontend/src/pages/search/types.ts
@@ -21,30 +21,29 @@ export interface TaxonomyResponse {
 // code → label lookup built from taxonomy API response
 export type LabelMap = Record<string, string>;
 
-export interface BestRoom {
+export interface SearchResult {
   roomId: string;
   roomType: string;
   bedType: string;
+  viewType: string;
   capacity: number;
   basePriceUsd: number;
   priceUsd: number | null;
   taxRatePct: number;
   estimatedTotalUsd: number;
   hasFlatFees: boolean;
-}
-
-export interface SearchResult {
-  id: string;
-  name: string;
-  city: string;
-  countryCode: string;
-  neighborhood: string | null;
-  thumbnailUrl: string;
-  amenities: string[];
-  stars: number;
-  rating: number;
-  reviewCount: number;
-  bestRoom: BestRoom;
+  property: {
+    id: string;
+    name: string;
+    city: string;
+    countryCode: string;
+    neighborhood: string | null;
+    stars: number;
+    rating: number;
+    reviewCount: number;
+    thumbnailUrl: string;
+    amenities: string[];
+  };
 }
 
 export interface FacetItem {

--- a/services/search-service/src/properties/dto/property-rooms.dto.ts
+++ b/services/search-service/src/properties/dto/property-rooms.dto.ts
@@ -1,0 +1,5 @@
+export interface PropertyRoomsDto {
+  checkIn?: string;
+  checkOut?: string;
+  guests?: number;
+}

--- a/services/search-service/src/properties/facets/facets.service.spec.ts
+++ b/services/search-service/src/properties/facets/facets.service.spec.ts
@@ -252,16 +252,16 @@ describe("FacetsService", () => {
     });
   });
 
-  // ─── selectBestRoomPerProperty ────────────────────────────────────────────
+  // ─── selectCheapestRoomPerProperty ───────────────────────────────────────
 
-  describe("selectBestRoomPerProperty", () => {
+  describe("selectCheapestRoomPerProperty", () => {
     it("returns one result per property", () => {
       const rooms = [
         makeRoom({ room_id: "r1", property_id: "p1", base_price_usd: "100" }),
         makeRoom({ room_id: "r2", property_id: "p1", base_price_usd: "80" }),
         makeRoom({ room_id: "r3", property_id: "p2", base_price_usd: "200" }),
       ];
-      expect(service.selectBestRoomPerProperty(rooms)).toHaveLength(2);
+      expect(service.selectCheapestRoomPerProperty(rooms)).toHaveLength(2);
     });
 
     it("selects the cheapest room per property by base_price_usd", () => {
@@ -269,8 +269,8 @@ describe("FacetsService", () => {
         makeRoom({ room_id: "r1", property_id: "p1", base_price_usd: "200" }),
         makeRoom({ room_id: "r2", property_id: "p1", base_price_usd: "80" }),
       ];
-      const result = service.selectBestRoomPerProperty(rooms);
-      expect(result[0].bestRoom.roomId).toBe("r2");
+      const result = service.selectCheapestRoomPerProperty(rooms);
+      expect(result[0].roomId).toBe("r2");
     });
 
     it("prefers avail_price_usd over base_price_usd for sorting", () => {
@@ -288,14 +288,14 @@ describe("FacetsService", () => {
           avail_price_usd: "100",
         }),
       ];
-      const result = service.selectBestRoomPerProperty(rooms);
-      expect(result[0].bestRoom.roomId).toBe("r2");
+      const result = service.selectCheapestRoomPerProperty(rooms);
+      expect(result[0].roomId).toBe("r2");
     });
 
     it("exposes priceUsd as null when no availability", () => {
       const rooms = [makeRoom({ avail_price_usd: null })];
-      const result = service.selectBestRoomPerProperty(rooms);
-      expect(result[0].bestRoom.priceUsd).toBeNull();
+      const result = service.selectCheapestRoomPerProperty(rooms);
+      expect(result[0].priceUsd).toBeNull();
     });
 
     it("unions amenities across all rooms of a property", () => {
@@ -311,8 +311,8 @@ describe("FacetsService", () => {
           amenities: ["gym", "spa"],
         }),
       ];
-      const result = service.selectBestRoomPerProperty(rooms);
-      expect(result[0].amenities).toEqual(
+      const result = service.selectCheapestRoomPerProperty(rooms);
+      expect(result[0].property.amenities).toEqual(
         expect.arrayContaining(["wifi", "pool", "gym", "spa"]),
       );
     });
@@ -331,9 +331,9 @@ describe("FacetsService", () => {
           flat_fee_per_stay_usd: "30",
         }),
       ];
-      const result = service.selectBestRoomPerProperty(rooms, 0);
+      const result = service.selectCheapestRoomPerProperty(rooms, 0);
       // 150 × 1.16 + 10 = 174 + 10 = 184
-      expect(result[0].bestRoom.estimatedTotalUsd).toBeCloseTo(184, 2);
+      expect(result[0].estimatedTotalUsd).toBeCloseTo(184, 2);
     });
 
     it("dated (nights=3): price × nights × (1 + tax/100) + flatNight × nights + flatStay", () => {
@@ -345,33 +345,33 @@ describe("FacetsService", () => {
           flat_fee_per_stay_usd: "30",
         }),
       ];
-      const result = service.selectBestRoomPerProperty(rooms, 3);
+      const result = service.selectCheapestRoomPerProperty(rooms, 3);
       // 150 × 3 × 1.16 + 10 × 3 + 30 = 522 + 30 + 30 = 582
-      expect(result[0].bestRoom.estimatedTotalUsd).toBeCloseTo(582, 2);
+      expect(result[0].estimatedTotalUsd).toBeCloseTo(582, 2);
     });
 
     it("hasFlatFees=true when flat_fee_per_night_usd > 0", () => {
       const rooms = [
         makeRoom({ flat_fee_per_night_usd: "10", flat_fee_per_stay_usd: "0" }),
       ];
-      const result = service.selectBestRoomPerProperty(rooms, 0);
-      expect(result[0].bestRoom.hasFlatFees).toBe(true);
+      const result = service.selectCheapestRoomPerProperty(rooms, 0);
+      expect(result[0].hasFlatFees).toBe(true);
     });
 
     it("hasFlatFees=true when flat_fee_per_stay_usd > 0", () => {
       const rooms = [
         makeRoom({ flat_fee_per_night_usd: "0", flat_fee_per_stay_usd: "50" }),
       ];
-      const result = service.selectBestRoomPerProperty(rooms, 0);
-      expect(result[0].bestRoom.hasFlatFees).toBe(true);
+      const result = service.selectCheapestRoomPerProperty(rooms, 0);
+      expect(result[0].hasFlatFees).toBe(true);
     });
 
     it("hasFlatFees=false when both flat fee columns are 0", () => {
       const rooms = [
         makeRoom({ flat_fee_per_night_usd: "0", flat_fee_per_stay_usd: "0" }),
       ];
-      const result = service.selectBestRoomPerProperty(rooms, 0);
-      expect(result[0].bestRoom.hasFlatFees).toBe(false);
+      const result = service.selectCheapestRoomPerProperty(rooms, 0);
+      expect(result[0].hasFlatFees).toBe(false);
     });
 
     it("Colombia (IVA 19% + INC 8% = 27%): correct per-night estimate", () => {
@@ -383,83 +383,179 @@ describe("FacetsService", () => {
           flat_fee_per_stay_usd: "0",
         }),
       ];
-      const result = service.selectBestRoomPerProperty(rooms, 0);
+      const result = service.selectCheapestRoomPerProperty(rooms, 0);
       // 200 × 1.27 = 254
-      expect(result[0].bestRoom.estimatedTotalUsd).toBeCloseTo(254, 2);
-      expect(result[0].bestRoom.taxRatePct).toBe(27);
+      expect(result[0].estimatedTotalUsd).toBeCloseTo(254, 2);
+      expect(result[0].taxRatePct).toBe(27);
     });
   });
 
-  // ─── sortProperties ───────────────────────────────────────────────────────
+  // ─── sortRooms ────────────────────────────────────────────────────────────
 
-  describe("sortProperties", () => {
-    const makeProperty = (
+  describe("sortRooms", () => {
+    const makeRoomResult = (
       id: string,
       price: number,
       stars: number,
       rating: number,
-    ): ReturnType<FacetsService["selectBestRoomPerProperty"]>[0] => ({
-      id: id,
-      name: `Hotel ${id}`,
-      city: "Lisbon",
-      countryCode: "PT",
-      neighborhood: null,
-      stars,
-      rating,
-      reviewCount: 10,
-      thumbnailUrl: "",
-      amenities: [],
-      bestRoom: {
-        roomId: `room-${id}`,
-        roomType: "suite",
-        bedType: "king",
-        capacity: 2,
-        basePriceUsd: price,
-        priceUsd: price,
-        taxRatePct: 0,
-        estimatedTotalUsd: price,
-        hasFlatFees: false,
+    ): ReturnType<FacetsService["selectCheapestRoomPerProperty"]>[0] => ({
+      roomId: `room-${id}`,
+      roomType: "suite",
+      bedType: "king",
+      viewType: "ocean",
+      capacity: 2,
+      basePriceUsd: price,
+      priceUsd: price,
+      taxRatePct: 0,
+      estimatedTotalUsd: price,
+      hasFlatFees: false,
+      property: {
+        id,
+        name: `Hotel ${id}`,
+        city: "Lisbon",
+        countryCode: "PT",
+        neighborhood: null,
+        stars,
+        rating,
+        reviewCount: 10,
+        thumbnailUrl: "",
+        amenities: [],
       },
     });
 
     it("sorts by price_asc", () => {
-      const props = [
-        makeProperty("p1", 200, 4, 4.0),
-        makeProperty("p2", 100, 3, 3.5),
+      const rooms = [
+        makeRoomResult("p1", 200, 4, 4.0),
+        makeRoomResult("p2", 100, 3, 3.5),
       ];
-      const sorted = service.sortProperties(props, "price_asc");
-      expect(sorted[0].id).toBe("p2");
+      const sorted = service.sortRooms(rooms, "price_asc");
+      expect(sorted[0].property.id).toBe("p2");
     });
 
     it("sorts by price_desc", () => {
-      const props = [
-        makeProperty("p1", 100, 4, 4.0),
-        makeProperty("p2", 200, 3, 3.5),
+      const rooms = [
+        makeRoomResult("p1", 100, 4, 4.0),
+        makeRoomResult("p2", 200, 3, 3.5),
       ];
-      const sorted = service.sortProperties(props, "price_desc");
-      expect(sorted[0].id).toBe("p2");
+      const sorted = service.sortRooms(rooms, "price_desc");
+      expect(sorted[0].property.id).toBe("p2");
     });
 
     it("sorts by stars_desc, then rating desc as tiebreaker", () => {
-      const props = [
-        makeProperty("p1", 100, 4, 3.5),
-        makeProperty("p2", 200, 4, 4.5),
-        makeProperty("p3", 150, 5, 3.0),
+      const rooms = [
+        makeRoomResult("p1", 100, 4, 3.5),
+        makeRoomResult("p2", 200, 4, 4.5),
+        makeRoomResult("p3", 150, 5, 3.0),
       ];
-      const sorted = service.sortProperties(props, "stars_desc");
-      expect(sorted[0].id).toBe("p3");
-      expect(sorted[1].id).toBe("p2");
-      expect(sorted[2].id).toBe("p1");
+      const sorted = service.sortRooms(rooms, "stars_desc");
+      expect(sorted[0].property.id).toBe("p3");
+      expect(sorted[1].property.id).toBe("p2");
+      expect(sorted[2].property.id).toBe("p1");
     });
 
     it("does not mutate the original array", () => {
-      const props = [
-        makeProperty("p1", 200, 4, 4.0),
-        makeProperty("p2", 100, 4, 4.0),
+      const rooms = [
+        makeRoomResult("p1", 200, 4, 4.0),
+        makeRoomResult("p2", 100, 4, 4.0),
       ];
-      const original = [...props];
-      service.sortProperties(props, "price_asc");
-      expect(props[0].id).toBe(original[0].id);
+      const original = [...rooms];
+      service.sortRooms(rooms, "price_asc");
+      expect(rooms[0].property.id).toBe(original[0].property.id);
+    });
+  });
+
+  // ─── mapAllRooms ──────────────────────────────────────────────────────────
+
+  describe("mapAllRooms", () => {
+    it("returns empty array when given no rooms", () => {
+      expect(service.mapAllRooms([])).toEqual([]);
+    });
+
+    it("returns one result per room (no grouping)", () => {
+      const rooms = [
+        makeRoom({ room_id: "r1", property_id: "p1", base_price_usd: "100" }),
+        makeRoom({ room_id: "r2", property_id: "p1", base_price_usd: "200" }),
+        makeRoom({ room_id: "r3", property_id: "p1", base_price_usd: "150" }),
+      ];
+      expect(service.mapAllRooms(rooms)).toHaveLength(3);
+    });
+
+    it("maps roomId, roomType, bedType, viewType, capacity correctly", () => {
+      const room = makeRoom({
+        room_id: "r1",
+        room_type: "suite",
+        bed_type: "king",
+        view_type: "ocean",
+        capacity: 3,
+      });
+      const result = service.mapAllRooms([room]);
+      expect(result[0].roomId).toBe("r1");
+      expect(result[0].roomType).toBe("suite");
+      expect(result[0].bedType).toBe("king");
+      expect(result[0].viewType).toBe("ocean");
+      expect(result[0].capacity).toBe(3);
+    });
+
+    it("computes estimatedTotalUsd using the same formula as selectCheapestRoomPerProperty", () => {
+      // base $150, tax 16%, 3 nights, flatNight $10, flatStay $30
+      const room = makeRoom({
+        base_price_usd: "150",
+        tax_rate_pct: "16",
+        flat_fee_per_night_usd: "10",
+        flat_fee_per_stay_usd: "30",
+      });
+      const result = service.mapAllRooms([room], 3);
+      // 150 × 3 × 1.16 + 10 × 3 + 30 = 522 + 30 + 30 = 582
+      expect(result[0].estimatedTotalUsd).toBeCloseTo(582, 2);
+    });
+
+    it("uses avail_price_usd when present", () => {
+      const room = makeRoom({
+        base_price_usd: "200",
+        avail_price_usd: "120",
+      });
+      const result = service.mapAllRooms([room], 0);
+      expect(result[0].priceUsd).toBe(120);
+      expect(result[0].basePriceUsd).toBe(200);
+    });
+
+    it("sets priceUsd to null when avail_price_usd is null", () => {
+      const room = makeRoom({ avail_price_usd: null });
+      const result = service.mapAllRooms([room]);
+      expect(result[0].priceUsd).toBeNull();
+    });
+
+    it("unions amenities across all rooms in property.amenities", () => {
+      const rooms = [
+        makeRoom({ room_id: "r1", amenities: ["wifi", "pool"] }),
+        makeRoom({ room_id: "r2", amenities: ["gym", "spa"] }),
+      ];
+      const result = service.mapAllRooms(rooms);
+      expect(result[0].property.amenities).toEqual(
+        expect.arrayContaining(["wifi", "pool", "gym", "spa"]),
+      );
+      expect(result[1].property.amenities).toEqual(
+        expect.arrayContaining(["wifi", "pool", "gym", "spa"]),
+      );
+    });
+
+    it("exposes the same property info on every room result", () => {
+      const rooms = [
+        makeRoom({
+          room_id: "r1",
+          property_id: "p1",
+          property_name: "Grand Hotel",
+        }),
+        makeRoom({
+          room_id: "r2",
+          property_id: "p1",
+          property_name: "Grand Hotel",
+        }),
+      ];
+      const result = service.mapAllRooms(rooms);
+      expect(result[0].property.id).toBe("p1");
+      expect(result[1].property.id).toBe("p1");
+      expect(result[0].property.name).toBe("Grand Hotel");
     });
   });
 

--- a/services/search-service/src/properties/facets/facets.service.ts
+++ b/services/search-service/src/properties/facets/facets.service.ts
@@ -27,29 +27,30 @@ export interface CandidateRoom {
   avail_price_usd: string | null;
 }
 
-export interface PropertyResult {
-  id: string;
-  name: string;
-  city: string;
-  countryCode: string;
-  neighborhood: string | null;
-  stars: number;
-  rating: number;
-  reviewCount: number;
-  thumbnailUrl: string;
-  amenities: string[];
+export interface RoomSearchResult {
+  roomId: string;
+  roomType: string;
+  bedType: string;
+  viewType: string;
+  capacity: number;
+  basePriceUsd: number;
+  priceUsd: number | null;
+  taxRatePct: number;
+  estimatedTotalUsd: number;
+  hasFlatFees: boolean;
   /** Internal field used for flat fee enrichment — not in final API response shape */
   _partnerId?: string;
-  bestRoom: {
-    roomId: string;
-    roomType: string;
-    bedType: string;
-    capacity: number;
-    basePriceUsd: number;
-    priceUsd: number | null;
-    taxRatePct: number;
-    estimatedTotalUsd: number;
-    hasFlatFees: boolean;
+  property: {
+    id: string;
+    name: string;
+    city: string;
+    countryCode: string;
+    neighborhood: string | null;
+    stars: number;
+    rating: number;
+    reviewCount: number;
+    thumbnailUrl: string;
+    amenities: string[];
   };
 }
 
@@ -164,10 +165,10 @@ export class FacetsService {
     };
   }
 
-  selectBestRoomPerProperty(
+  selectCheapestRoomPerProperty(
     rooms: CandidateRoom[],
     nights = 0,
-  ): PropertyResult[] {
+  ): RoomSearchResult[] {
     const byProperty = new Map<string, CandidateRoom[]>();
     for (const room of rooms) {
       const list = byProperty.get(room.property_id) ?? [];
@@ -175,7 +176,7 @@ export class FacetsService {
       byProperty.set(room.property_id, list);
     }
 
-    const results: PropertyResult[] = [];
+    const results: RoomSearchResult[] = [];
     for (const [, propertyRooms] of byProperty) {
       const best = propertyRooms.reduce((cheapest, room) => {
         const cp =
@@ -189,46 +190,25 @@ export class FacetsService {
         return rp < cp ? room : cheapest;
       });
 
-      const price =
-        best.avail_price_usd != null
-          ? parseFloat(best.avail_price_usd)
-          : parseFloat(best.base_price_usd);
-      const taxRatePct = parseFloat(best.tax_rate_pct ?? "0");
-      const flatPerNight = parseFloat(best.flat_fee_per_night_usd ?? "0");
-      const flatPerStay = parseFloat(best.flat_fee_per_stay_usd ?? "0");
-      const hasFlatFees = flatPerNight > 0 || flatPerStay > 0;
-      const estimatedTotalUsd =
-        nights > 0
-          ? price * nights * (1 + taxRatePct / 100) +
-            flatPerNight * nights +
-            flatPerStay
-          : price * (1 + taxRatePct / 100) + flatPerNight;
-
       results.push({
-        id: best.property_id,
-        name: best.property_name,
-        city: best.city,
-        countryCode: best.country,
-        neighborhood: best.neighborhood,
-        stars: best.stars,
-        rating: parseFloat(best.rating),
-        reviewCount: best.review_count,
-        thumbnailUrl: best.thumbnail_url,
-        amenities: [...new Set(propertyRooms.flatMap((r) => r.amenities))],
+        ...this.computePricing(best, nights),
+        roomId: best.room_id,
+        roomType: best.room_type,
+        bedType: best.bed_type,
+        viewType: best.view_type,
+        capacity: best.capacity,
         _partnerId: best.partner_id,
-        bestRoom: {
-          roomId: best.room_id,
-          roomType: best.room_type,
-          bedType: best.bed_type,
-          capacity: best.capacity,
-          basePriceUsd: parseFloat(best.base_price_usd),
-          priceUsd:
-            best.avail_price_usd != null
-              ? parseFloat(best.avail_price_usd)
-              : null,
-          taxRatePct,
-          estimatedTotalUsd,
-          hasFlatFees,
+        property: {
+          id: best.property_id,
+          name: best.property_name,
+          city: best.city,
+          countryCode: best.country,
+          neighborhood: best.neighborhood,
+          stars: best.stars,
+          rating: parseFloat(best.rating),
+          reviewCount: best.review_count,
+          thumbnailUrl: best.thumbnail_url,
+          amenities: [...new Set(propertyRooms.flatMap((r) => r.amenities))],
         },
       });
     }
@@ -236,38 +216,113 @@ export class FacetsService {
     return results;
   }
 
-  sortProperties(
-    properties: PropertyResult[],
+  /**
+   * Maps every candidate room to a RoomSearchResult without grouping by property.
+   * All rooms must belong to the same property — property.amenities is the union
+   * across all of them.
+   */
+  mapAllRooms(rooms: CandidateRoom[], nights = 0): RoomSearchResult[] {
+    if (rooms.length === 0) return [];
+
+    const propertyAmenities = [...new Set(rooms.flatMap((r) => r.amenities))];
+    const first = rooms[0];
+
+    return rooms.map((room) => ({
+      ...this.computePricing(room, nights),
+      roomId: room.room_id,
+      roomType: room.room_type,
+      bedType: room.bed_type,
+      viewType: room.view_type,
+      capacity: room.capacity,
+      _partnerId: room.partner_id,
+      property: {
+        id: first.property_id,
+        name: first.property_name,
+        city: first.city,
+        countryCode: first.country,
+        neighborhood: first.neighborhood,
+        stars: first.stars,
+        rating: parseFloat(first.rating),
+        reviewCount: first.review_count,
+        thumbnailUrl: first.thumbnail_url,
+        amenities: propertyAmenities,
+      },
+    }));
+  }
+
+  sortRooms(
+    rooms: RoomSearchResult[],
     sort: SearchPropertiesDto["sort"],
-  ): PropertyResult[] {
-    const copy = [...properties];
+  ): RoomSearchResult[] {
+    const copy = [...rooms];
     switch (sort) {
       case "price_asc":
         copy.sort(
           (a, b) =>
-            (a.bestRoom.priceUsd ?? a.bestRoom.basePriceUsd) -
-            (b.bestRoom.priceUsd ?? b.bestRoom.basePriceUsd),
+            (a.priceUsd ?? a.basePriceUsd) - (b.priceUsd ?? b.basePriceUsd),
         );
         break;
       case "price_desc":
         copy.sort(
           (a, b) =>
-            (b.bestRoom.priceUsd ?? b.bestRoom.basePriceUsd) -
-            (a.bestRoom.priceUsd ?? a.bestRoom.basePriceUsd),
+            (b.priceUsd ?? b.basePriceUsd) - (a.priceUsd ?? a.basePriceUsd),
         );
         break;
       case "stars_desc":
-        copy.sort((a, b) => b.stars - a.stars || b.rating - a.rating);
+        copy.sort(
+          (a, b) =>
+            b.property.stars - a.property.stars ||
+            b.property.rating - a.property.rating,
+        );
         break;
       case "relevance":
       default:
-        copy.sort((a, b) => b.stars - a.stars || b.rating - a.rating);
+        copy.sort(
+          (a, b) =>
+            b.property.stars - a.property.stars ||
+            b.property.rating - a.property.rating,
+        );
         break;
     }
     return copy;
   }
 
   // ─── private helpers ───────────────────────────────────────────────────────
+
+  private computePricing(
+    room: CandidateRoom,
+    nights: number,
+  ): Pick<
+    RoomSearchResult,
+    | "basePriceUsd"
+    | "priceUsd"
+    | "taxRatePct"
+    | "estimatedTotalUsd"
+    | "hasFlatFees"
+  > {
+    const price =
+      room.avail_price_usd != null
+        ? parseFloat(room.avail_price_usd)
+        : parseFloat(room.base_price_usd);
+    const taxRatePct = parseFloat(room.tax_rate_pct ?? "0");
+    const flatPerNight = parseFloat(room.flat_fee_per_night_usd ?? "0");
+    const flatPerStay = parseFloat(room.flat_fee_per_stay_usd ?? "0");
+    const hasFlatFees = flatPerNight > 0 || flatPerStay > 0;
+    const estimatedTotalUsd =
+      nights > 0
+        ? price * nights * (1 + taxRatePct / 100) +
+          flatPerNight * nights +
+          flatPerStay
+        : price * (1 + taxRatePct / 100) + flatPerNight;
+    return {
+      basePriceUsd: parseFloat(room.base_price_usd),
+      priceUsd:
+        room.avail_price_usd != null ? parseFloat(room.avail_price_usd) : null,
+      taxRatePct,
+      estimatedTotalUsd,
+      hasFlatFees,
+    };
+  }
 
   private countByField(
     rooms: CandidateRoom[],

--- a/services/search-service/src/properties/properties.controller.spec.ts
+++ b/services/search-service/src/properties/properties.controller.spec.ts
@@ -5,13 +5,19 @@ import type { PropertiesService } from "./properties.service.js";
 describe("PropertiesController", () => {
   let controller: PropertiesController;
   let service: jest.Mocked<
-    Pick<PropertiesService, "searchProperties" | "getCitySuggestions">
+    Pick<
+      PropertiesService,
+      "searchProperties" | "getCitySuggestions" | "getPropertyRooms"
+    >
   >;
 
   beforeEach(() => {
     service = {
       searchProperties: jest.fn().mockResolvedValue({ results: [] }),
       getCitySuggestions: jest.fn().mockReturnValue({ suggestions: [] }),
+      getPropertyRooms: jest
+        .fn()
+        .mockResolvedValue({ property: null, rooms: [] }),
     };
     controller = new PropertiesController(
       service as unknown as PropertiesService,
@@ -260,6 +266,73 @@ describe("PropertiesController", () => {
       expect(() => controller.getCitySuggestions("   ")).toThrow(
         BadRequestException,
       );
+    });
+  });
+
+  describe("GET properties/:propertyId/rooms", () => {
+    it("delegates to service with propertyId and parsed options", async () => {
+      await controller.getPropertyRooms("p1", {
+        checkIn: "2026-04-01",
+        checkOut: "2026-04-05",
+        guests: "2",
+      });
+      expect(service.getPropertyRooms).toHaveBeenCalledWith("p1", {
+        checkIn: "2026-04-01",
+        checkOut: "2026-04-05",
+        guests: 2,
+      });
+    });
+
+    it("returns the service response", async () => {
+      const mockResponse = {
+        property: { id: "p1", name: "Hotel A" },
+        rooms: [],
+      };
+      (service.getPropertyRooms as jest.Mock).mockResolvedValue(mockResponse);
+      const result = await controller.getPropertyRooms("p1", {});
+      expect(result).toEqual(mockResponse);
+    });
+
+    it("omits checkIn/checkOut/guests when not provided", async () => {
+      await controller.getPropertyRooms("p1", {});
+      expect(service.getPropertyRooms).toHaveBeenCalledWith("p1", {
+        checkIn: undefined,
+        checkOut: undefined,
+        guests: undefined,
+      });
+    });
+
+    it("throws BadRequestException for invalid checkIn", () => {
+      expect(() =>
+        controller.getPropertyRooms("p1", { checkIn: "not-a-date" }),
+      ).toThrow(BadRequestException);
+    });
+
+    it("throws BadRequestException for invalid checkOut", () => {
+      expect(() =>
+        controller.getPropertyRooms("p1", { checkOut: "not-a-date" }),
+      ).toThrow(BadRequestException);
+    });
+
+    it("throws BadRequestException when checkOut equals checkIn", () => {
+      expect(() =>
+        controller.getPropertyRooms("p1", {
+          checkIn: "2026-04-01",
+          checkOut: "2026-04-01",
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it("throws BadRequestException for guests = 0", () => {
+      expect(() => controller.getPropertyRooms("p1", { guests: "0" })).toThrow(
+        BadRequestException,
+      );
+    });
+
+    it("throws BadRequestException for non-numeric guests", () => {
+      expect(() =>
+        controller.getPropertyRooms("p1", { guests: "abc" }),
+      ).toThrow(BadRequestException);
     });
   });
 });

--- a/services/search-service/src/properties/properties.controller.ts
+++ b/services/search-service/src/properties/properties.controller.ts
@@ -1,4 +1,10 @@
-import { BadRequestException, Controller, Get, Query } from "@nestjs/common";
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  Param,
+  Query,
+} from "@nestjs/common";
 import { PropertiesService } from "./properties.service.js";
 import type {
   SearchPropertiesDto,
@@ -26,6 +32,35 @@ export class PropertiesController {
   searchProperties(@Query() query: Record<string, string>) {
     const dto = this.parseQuery(query);
     return this.propertiesService.searchProperties(dto);
+  }
+
+  @Get("properties/:propertyId/rooms")
+  getPropertyRooms(
+    @Param("propertyId") propertyId: string,
+    @Query() query: Record<string, string>,
+  ) {
+    const { checkIn, checkOut, guests } = query;
+
+    if (checkIn && isNaN(new Date(checkIn).getTime())) {
+      throw new BadRequestException("checkIn must be a valid ISO 8601 date");
+    }
+    if (checkOut && isNaN(new Date(checkOut).getTime())) {
+      throw new BadRequestException("checkOut must be a valid ISO 8601 date");
+    }
+    if (checkIn && checkOut && new Date(checkOut) <= new Date(checkIn)) {
+      throw new BadRequestException("checkOut must be after checkIn");
+    }
+
+    const guestsNum = guests ? parseInt(guests, 10) : undefined;
+    if (guestsNum !== undefined && (isNaN(guestsNum) || guestsNum < 1)) {
+      throw new BadRequestException("guests must be a positive integer");
+    }
+
+    return this.propertiesService.getPropertyRooms(propertyId, {
+      checkIn: checkIn || undefined,
+      checkOut: checkOut || undefined,
+      guests: guestsNum,
+    });
   }
 
   @Get("cities")

--- a/services/search-service/src/properties/properties.repository.spec.ts
+++ b/services/search-service/src/properties/properties.repository.spec.ts
@@ -152,6 +152,29 @@ describe("PropertiesRepository", () => {
     });
   });
 
+  describe("findByPropertyId", () => {
+    it("queries room_search_index by property_id", async () => {
+      const { repo, db } = makeRepo();
+      await repo.findByPropertyId("p1");
+      expect(db.selectFrom).toHaveBeenCalledWith("room_search_index as rsi");
+    });
+
+    it("applies guests filter via $if when guests is provided", async () => {
+      const { repo, queryChain } = makeRepo();
+      await repo.findByPropertyId("p1", { guests: 2 });
+      const ifCalls = queryChain.$if.mock.calls;
+      // guests=2 → truthy → condition is true
+      expect(ifCalls[0][0]).toBe(true);
+    });
+
+    it("skips guests filter via $if when guests is not provided", async () => {
+      const { repo, queryChain } = makeRepo();
+      await repo.findByPropertyId("p1", {});
+      const ifCalls = queryChain.$if.mock.calls;
+      expect(ifCalls[0][0]).toBe(false);
+    });
+  });
+
   describe("findRoomCity", () => {
     it("returns city when room is found", async () => {
       const chain = makeQueryChain([{ city: "Lisbon" }]);

--- a/services/search-service/src/properties/properties.repository.ts
+++ b/services/search-service/src/properties/properties.repository.ts
@@ -1,10 +1,6 @@
 import { Inject, Injectable } from "@nestjs/common";
 import { Kysely, sql, type SqlBool } from "kysely";
-import type { Selectable } from "kysely";
-import type {
-  SearchDatabase,
-  RoomSearchIndexTable,
-} from "../database/database.types.js";
+import type { SearchDatabase } from "../database/database.types.js";
 import { KYSELY } from "../database/database.provider.js";
 import type { CandidateRoom } from "./facets/facets.service.js";
 import type { SearchPropertiesDto } from "./dto/search-properties.dto.js";
@@ -188,18 +184,18 @@ export class PropertiesRepository {
 
   async findByPropertyId(
     propertyId: string,
-  ): Promise<Selectable<RoomSearchIndexTable>[]> {
-    return this.db
+    opts: { checkIn?: string; checkOut?: string; guests?: number } = {},
+  ): Promise<CandidateRoom[]> {
+    const rows = await this.db
       .selectFrom("room_search_index as rsi")
       .select([
         "rsi.room_id",
         "rsi.property_id",
+        "rsi.partner_id",
         "rsi.property_name",
         "rsi.city",
         "rsi.country",
         "rsi.neighborhood",
-        "rsi.lat",
-        "rsi.lon",
         "rsi.stars",
         "rsi.rating",
         "rsi.review_count",
@@ -210,10 +206,24 @@ export class PropertiesRepository {
         "rsi.view_type",
         "rsi.capacity",
         "rsi.base_price_usd",
+        "rsi.tax_rate_pct",
+        "rsi.flat_fee_per_night_usd",
+        "rsi.flat_fee_per_stay_usd",
+        sql<string | null>`(
+          SELECT rpp.price_usd::text
+          FROM room_price_periods rpp
+          WHERE rpp.room_id = rsi.room_id
+            AND rpp.from_date <= ${opts.checkIn || "9999-12-31"}::date
+            AND rpp.to_date   >= ${opts.checkOut || "0001-01-01"}::date
+          LIMIT 1
+        )`.as("avail_price_usd"),
       ])
       .where("rsi.property_id", "=", propertyId)
       .where("rsi.is_active", "=", true)
-      .execute() as Promise<Selectable<RoomSearchIndexTable>[]>;
+      .$if(!!opts.guests, (qb) => qb.where("rsi.capacity", ">=", opts.guests!))
+      .execute();
+
+    return rows as CandidateRoom[];
   }
 
   async deactivateRoom(roomId: string): Promise<void> {

--- a/services/search-service/src/properties/properties.service.spec.ts
+++ b/services/search-service/src/properties/properties.service.spec.ts
@@ -30,27 +30,28 @@ const mockRoom = {
   flat_fee_per_stay_usd: "0",
 };
 
-const mockProperty = {
-  id: "p1",
-  name: "Hotel A",
-  city: "Lisbon",
-  countryCode: "PT",
-  neighborhood: null,
-  stars: 4,
-  rating: 4.0,
-  reviewCount: 10,
-  thumbnailUrl: "",
-  amenities: ["wifi"],
-  bestRoom: {
-    roomId: "r1",
-    roomType: "suite",
-    bedType: "king",
-    capacity: 2,
-    basePriceUsd: 200,
-    priceUsd: 180,
-    taxRatePct: 0,
-    estimatedTotalUsd: 720,
-    hasFlatFees: false,
+const mockRoomResult = {
+  roomId: "r1",
+  roomType: "suite",
+  bedType: "king",
+  viewType: "ocean",
+  capacity: 2,
+  basePriceUsd: 200,
+  priceUsd: 180,
+  taxRatePct: 0,
+  estimatedTotalUsd: 720,
+  hasFlatFees: false,
+  property: {
+    id: "p1",
+    name: "Hotel A",
+    city: "Lisbon",
+    countryCode: "PT",
+    neighborhood: null,
+    stars: 4,
+    rating: 4.0,
+    reviewCount: 10,
+    thumbnailUrl: "",
+    amenities: ["wifi"],
   },
 };
 
@@ -67,8 +68,11 @@ const baseDto: SearchPropertiesDto = {
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 function makeServices(candidateRows = [mockRoom]) {
-  const repo: jest.Mocked<Pick<PropertiesRepository, "findCandidates">> = {
+  const repo: jest.Mocked<
+    Pick<PropertiesRepository, "findCandidates" | "findByPropertyId">
+  > = {
     findCandidates: jest.fn().mockResolvedValue(candidateRows),
+    findByPropertyId: jest.fn().mockResolvedValue(candidateRows),
   };
 
   const cache: jest.Mocked<Pick<CacheService, "get" | "set" | "scanDel">> = {
@@ -87,8 +91,9 @@ function makeServices(candidateRows = [mockRoom]) {
       stars: [],
       priceRange: { min: 180, max: 180, currency: "USD" },
     }),
-    selectBestRoomPerProperty: jest.fn().mockReturnValue([mockProperty]),
-    sortProperties: jest.fn().mockReturnValue([mockProperty]),
+    selectCheapestRoomPerProperty: jest.fn().mockReturnValue([mockRoomResult]),
+    sortRooms: jest.fn().mockReturnValue([mockRoomResult]),
+    mapAllRooms: jest.fn().mockReturnValue([mockRoomResult]),
   } as any;
 
   const inventoryClient: jest.Mocked<
@@ -142,10 +147,10 @@ describe("PropertiesService", () => {
       expect(typeof result.meta.searchId).toBe("string");
     });
 
-    it("returns the sorted properties as results", async () => {
+    it("returns the sorted rooms as results", async () => {
       const { service } = makeServices();
       const result = (await service.searchProperties(baseDto)) as any;
-      expect(result.results).toEqual([mockProperty]);
+      expect(result.results).toEqual([mockRoomResult]);
     });
 
     it("stores serialised response in cache with 5-minute TTL", async () => {
@@ -219,11 +224,11 @@ describe("PropertiesService", () => {
       expect(result.facets.priceRange.currency).toBe("USD");
     });
 
-    it("passes computed nights to selectBestRoomPerProperty", async () => {
+    it("passes computed nights to selectCheapestRoomPerProperty", async () => {
       const { service, mockFacets } = makeServices();
       // checkIn=2026-04-01, checkOut=2026-04-05 → 4 nights
       await service.searchProperties(baseDto);
-      expect(mockFacets.selectBestRoomPerProperty).toHaveBeenCalledWith(
+      expect(mockFacets.selectCheapestRoomPerProperty).toHaveBeenCalledWith(
         expect.anything(),
         4,
       );
@@ -236,7 +241,7 @@ describe("PropertiesService", () => {
         checkIn: undefined,
         checkOut: undefined,
       });
-      expect(mockFacets.selectBestRoomPerProperty).toHaveBeenCalledWith(
+      expect(mockFacets.selectCheapestRoomPerProperty).toHaveBeenCalledWith(
         expect.anything(),
         0,
       );
@@ -291,11 +296,11 @@ describe("PropertiesService", () => {
   describe("pagination", () => {
     it("slices results according to page and pageSize", async () => {
       const { service, mockFacets } = makeServices();
-      const props = Array.from({ length: 7 }, (_, i) => ({
-        ...mockProperty,
-        id: `p${i}`,
+      const rooms = Array.from({ length: 7 }, (_, i) => ({
+        ...mockRoomResult,
+        property: { ...mockRoomResult.property, id: `p${i}` },
       }));
-      mockFacets.sortProperties.mockReturnValue(props);
+      mockFacets.sortRooms.mockReturnValue(rooms);
 
       const result = (await service.searchProperties({
         ...baseDto,
@@ -304,14 +309,14 @@ describe("PropertiesService", () => {
       })) as any;
 
       expect(result.results).toHaveLength(3);
-      expect(result.results[0].id).toBe("p3");
+      expect(result.results[0].property.id).toBe("p3");
       expect(result.meta.total).toBe(7);
       expect(result.meta.totalPages).toBe(3);
     });
 
     it("returns empty results for a page beyond total", async () => {
       const { service, mockFacets } = makeServices();
-      mockFacets.sortProperties.mockReturnValue([mockProperty]);
+      mockFacets.sortRooms.mockReturnValue([mockRoomResult]);
 
       const result = (await service.searchProperties({
         ...baseDto,
@@ -402,6 +407,83 @@ describe("PropertiesService", () => {
       const key2 = (cache.set as jest.Mock).mock.calls[0][0] as string;
 
       expect(key1).toBe(key2);
+    });
+  });
+
+  describe("getPropertyRooms", () => {
+    it("queries repo with propertyId and passes dates/guests through", async () => {
+      const { service, repo } = makeServices();
+      await service.getPropertyRooms("p1", {
+        checkIn: "2026-04-01",
+        checkOut: "2026-04-05",
+        guests: 2,
+      });
+      expect(repo.findByPropertyId).toHaveBeenCalledWith("p1", {
+        checkIn: "2026-04-01",
+        checkOut: "2026-04-05",
+        guests: 2,
+      });
+    });
+
+    it("hoists shared property info to top level", async () => {
+      const { service } = makeServices();
+      const result = (await service.getPropertyRooms("p1", {})) as any;
+      expect(result.property).toEqual(mockRoomResult.property);
+    });
+
+    it("strips property and _partnerId from each room entry", async () => {
+      const { service } = makeServices();
+      const result = (await service.getPropertyRooms("p1", {})) as any;
+      expect(result.rooms[0].property).toBeUndefined();
+      expect(result.rooms[0]._partnerId).toBeUndefined();
+    });
+
+    it("room entries include roomId, roomType, bedType, viewType, pricing fields", async () => {
+      const { service } = makeServices();
+      const result = (await service.getPropertyRooms("p1", {})) as any;
+      const room = result.rooms[0];
+      expect(room.roomId).toBe(mockRoomResult.roomId);
+      expect(room.roomType).toBe(mockRoomResult.roomType);
+      expect(room.bedType).toBe(mockRoomResult.bedType);
+      expect(room.viewType).toBe(mockRoomResult.viewType);
+      expect(room.estimatedTotalUsd).toBeDefined();
+    });
+
+    it("returns { property: null, rooms: [] } when no rooms found", async () => {
+      const { service, mockFacets } = makeServices();
+      mockFacets.mapAllRooms.mockReturnValue([]);
+      const result = (await service.getPropertyRooms("p1", {})) as any;
+      expect(result.property).toBeNull();
+      expect(result.rooms).toEqual([]);
+    });
+
+    it("calls inventoryClient when dates are provided", async () => {
+      const { service, inventoryClient } = makeServices();
+      await service.getPropertyRooms("p1", {
+        checkIn: "2026-04-01",
+        checkOut: "2026-04-05",
+      });
+      expect(inventoryClient.checkAvailability).toHaveBeenCalledWith({
+        roomIds: [mockRoom.room_id],
+        fromDate: "2026-04-01",
+        toDate: "2026-04-05",
+      });
+    });
+
+    it("skips inventoryClient when no dates provided", async () => {
+      const { service, inventoryClient } = makeServices();
+      await service.getPropertyRooms("p1", {});
+      expect(inventoryClient.checkAvailability).not.toHaveBeenCalled();
+    });
+
+    it("passes computed nights to mapAllRooms", async () => {
+      const { service, mockFacets } = makeServices();
+      await service.getPropertyRooms("p1", {
+        checkIn: "2026-04-01",
+        checkOut: "2026-04-05",
+      });
+      // 4 nights
+      expect(mockFacets.mapAllRooms).toHaveBeenCalledWith(expect.anything(), 4);
     });
   });
 });

--- a/services/search-service/src/properties/properties.service.ts
+++ b/services/search-service/src/properties/properties.service.ts
@@ -5,6 +5,7 @@ import { CacheService } from "../cache/cache.service.js";
 import { FacetsService } from "./facets/facets.service.js";
 import { InventoryClientService } from "../inventory/inventory-client.service.js";
 import type { SearchPropertiesDto } from "./dto/search-properties.dto.js";
+import type { PropertyRoomsDto } from "./dto/property-rooms.dto.js";
 import { City } from "country-state-city";
 
 const CACHE_TTL = 60 * 5; // 5 minutes
@@ -63,9 +64,9 @@ export class PropertiesService {
     });
 
     const facetData = this.facets.computeFacets(available, dto);
-    const properties = this.facets.selectBestRoomPerProperty(filtered, nights);
+    const rooms = this.facets.selectCheapestRoomPerProperty(filtered, nights);
 
-    const sorted = this.facets.sortProperties(properties, dto.sort);
+    const sorted = this.facets.sortRooms(rooms, dto.sort);
 
     const total = sorted.length;
     const offset = (dto.page - 1) * dto.pageSize;
@@ -133,8 +134,8 @@ export class PropertiesService {
     if (cached) return JSON.parse(cached) as object;
 
     const candidates = await this.repo.findFeatured(limit * 5);
-    const properties = this.facets.selectBestRoomPerProperty(candidates, 0);
-    const sorted = this.facets.sortProperties(properties, "relevance");
+    const rooms = this.facets.selectCheapestRoomPerProperty(candidates, 0);
+    const sorted = this.facets.sortRooms(rooms, "relevance");
     const results = sorted
       .slice(0, limit)
       .map(({ _partnerId: _, ...rest }) => rest);
@@ -145,6 +146,52 @@ export class PropertiesService {
     };
     await this.cache.set(cacheKey, JSON.stringify(response), CACHE_TTL);
     return response;
+  }
+
+  async getPropertyRooms(propertyId: string, dto: PropertyRoomsDto) {
+    const nights =
+      dto.checkIn && dto.checkOut
+        ? Math.max(
+            0,
+            Math.round(
+              (new Date(dto.checkOut).getTime() -
+                new Date(dto.checkIn).getTime()) /
+                (1000 * 60 * 60 * 24),
+            ),
+          )
+        : 0;
+
+    const candidates = await this.repo.findByPropertyId(propertyId, {
+      checkIn: dto.checkIn,
+      checkOut: dto.checkOut,
+      guests: dto.guests,
+    });
+
+    let available = candidates;
+    if (dto.checkIn && dto.checkOut && candidates.length > 0) {
+      const candidateIds = candidates.map((r) => r.room_id);
+      const availableRooms = await this.inventoryClient.checkAvailability({
+        roomIds: candidateIds,
+        fromDate: dto.checkIn,
+        toDate: dto.checkOut,
+      });
+      const availableIds = new Set(availableRooms.map((r) => r.roomId));
+      available = candidates.filter((r) => availableIds.has(r.room_id));
+    }
+
+    const roomResults = this.facets.mapAllRooms(available, nights);
+
+    if (roomResults.length === 0) {
+      return { property: null, rooms: [] };
+    }
+
+    // All rooms share the same property — hoist it to the top level
+    const { property } = roomResults[0];
+    const rooms = roomResults.map(
+      ({ property: _, _partnerId: __, ...roomFields }) => roomFields,
+    );
+
+    return { property, rooms };
   }
 
   async invalidateCityCache(city: string): Promise<void> {

--- a/travelhub.postman_collection.json
+++ b/travelhub.postman_collection.json
@@ -63,6 +63,18 @@
       "value": "d1000000-0000-0000-0000-000000000001",
       "type": "string",
       "enabled": true
+    },
+    {
+      "key": "tax_rule_id",
+      "value": "",
+      "type": "string",
+      "enabled": true
+    },
+    {
+      "key": "fee_id",
+      "value": "",
+      "type": "string",
+      "enabled": true
     }
   ],
   "item": [
@@ -1331,6 +1343,91 @@
               "raw": "{\n  \"propertyId\": \"{{property_id}}\",\n  \"roomId\": \"{{room_id}}\",\n  \"partnerId\": \"{{partner_id}}\",\n  \"guestId\": \"{{guest_id}}\",\n  \"checkIn\": \"2026-06-01\",\n  \"checkOut\": \"2026-06-04\"\n}"
             }
           }
+        },
+        {
+          "name": "Tax Rules",
+          "item": [
+            {
+              "name": "List Tax Rules",
+              "request": {
+                "method": "GET",
+                "url": {
+                  "raw": "{{base_url}}/api/booking/tax-rules?country=MX",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "booking", "tax-rules"],
+                  "query": [
+                    { "key": "country", "value": "MX" }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "Get Tax Rule",
+              "request": {
+                "method": "GET",
+                "url": {
+                  "raw": "{{base_url}}/api/booking/tax-rules/{{tax_rule_id}}",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "booking", "tax-rules", "{{tax_rule_id}}"]
+                }
+              }
+            },
+            {
+              "name": "Create Tax Rule",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "const res = pm.response.json();",
+                      "if (res.id) pm.collectionVariables.set('tax_rule_id', res.id);"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "url": {
+                  "raw": "{{base_url}}/api/booking/tax-rules",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "booking", "tax-rules"]
+                },
+                "header": [{ "key": "Content-Type", "value": "application/json" }],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"country\": \"MX\",\n  \"city\": \"cancún\",\n  \"taxName\": \"ISH\",\n  \"taxType\": \"PERCENTAGE\",\n  \"rate\": 3,\n  \"currency\": \"USD\",\n  \"effectiveFrom\": \"2026-01-01\"\n}"
+                }
+              }
+            },
+            {
+              "name": "Update Tax Rule",
+              "request": {
+                "method": "PUT",
+                "url": {
+                  "raw": "{{base_url}}/api/booking/tax-rules/{{tax_rule_id}}",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "booking", "tax-rules", "{{tax_rule_id}}"]
+                },
+                "header": [{ "key": "Content-Type", "value": "application/json" }],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"rate\": 4,\n  \"effectiveFrom\": \"2026-06-01\"\n}"
+                }
+              }
+            },
+            {
+              "name": "Delete Tax Rule",
+              "request": {
+                "method": "DELETE",
+                "url": {
+                  "raw": "{{base_url}}/api/booking/tax-rules/{{tax_rule_id}}",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "booking", "tax-rules", "{{tax_rule_id}}"]
+                }
+              }
+            }
+          ]
         }
       ]
     },
@@ -1797,6 +1894,80 @@
               ]
             }
           }
+        },
+        {
+          "name": "Partner Fees",
+          "item": [
+            {
+              "name": "List Partner Fees",
+              "request": {
+                "method": "GET",
+                "url": {
+                  "raw": "{{base_url}}/api/partners/fees?partnerId={{partner_id}}",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "partners", "fees"],
+                  "query": [
+                    { "key": "partnerId", "value": "{{partner_id}}" }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "Create Partner Fee",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "exec": [
+                      "const res = pm.response.json();",
+                      "if (res.id) pm.collectionVariables.set('fee_id', res.id);"
+                    ],
+                    "type": "text/javascript"
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "url": {
+                  "raw": "{{base_url}}/api/partners/fees",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "partners", "fees"]
+                },
+                "header": [{ "key": "Content-Type", "value": "application/json" }],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"partnerId\": \"{{partner_id}}\",\n  \"feeName\": \"Resort Fee\",\n  \"feeType\": \"FLAT_PER_NIGHT\",\n  \"flatAmount\": 25,\n  \"currency\": \"USD\",\n  \"effectiveFrom\": \"2026-01-01\"\n}"
+                }
+              }
+            },
+            {
+              "name": "Update Partner Fee",
+              "request": {
+                "method": "PUT",
+                "url": {
+                  "raw": "{{base_url}}/api/partners/fees/{{fee_id}}",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "partners", "fees", "{{fee_id}}"]
+                },
+                "header": [{ "key": "Content-Type", "value": "application/json" }],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"partnerId\": \"{{partner_id}}\",\n  \"flatAmount\": 30\n}"
+                }
+              }
+            },
+            {
+              "name": "Delete Partner Fee",
+              "request": {
+                "method": "DELETE",
+                "url": {
+                  "raw": "{{base_url}}/api/partners/fees/{{fee_id}}",
+                  "host": ["{{base_url}}"],
+                  "path": ["api", "partners", "fees", "{{fee_id}}"]
+                }
+              }
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
## Descripción

Este PR implementa el cálculo de impuestos y tarifas de socios en el servicio de búsqueda, exponiéndolos en los resultados para que el frontend pueda mostrar el precio total estimado al usuario.

## Cambios principales

### `search-service`
- Se añaden los campos `taxRatePct`, `estimatedTotalUsd` y `hasFlatFees` en los resultados de búsqueda
- El repositorio ahora consulta la tabla de reglas de impuestos y tarifas planas de socios para calcular el total estimado por habitación
- Se agrega el DTO `property-rooms.dto.ts` para tipar correctamente la respuesta de habitaciones por propiedad
- Se actualiza el servicio de facetas (`facets.service`) para reflejar los nuevos campos
- Se actualizan todos los specs correspondientes

### `booking-service`
- Se añade la migración y seed al workflow de CI

### `frontend`
- El tipo `SearchResult` se reestructura: los campos de propiedad pasan a un objeto anidado `property`
- Se actualizan `ResultCard`, `SearchPage`, `PropertyDetailPage` y `HomePage` para usar la nueva estructura de tipos
- Se muestra el precio estimado con impuestos incluidos en las tarjetas de resultados

### `docs`
- Se agrega la colección de Postman con ejemplos de Tax Rules y Partner Fees

## Plan de pruebas

- [ ] Verificar que los resultados de búsqueda incluyen `taxRatePct`, `estimatedTotalUsd` y `hasFlatFees`
- [ ] Confirmar que el frontend muestra el precio total estimado correctamente en `ResultCard` y `PropertyDetailPage`
- [ ] Ejecutar `nx test search-service` y `nx test frontend` — todos los specs deben pasar
- [ ] Probar el flujo completo: búsqueda → detalle de propiedad → precio con impuestos visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)