### PR TITLE
feat(mobile): add CI build pipeline with EAS Build

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -16,11 +16,6 @@ on:
         description: 'GitHub release tag to attach artifacts to (e.g. v1.0.0). Leave empty to skip.'
         required: false
         type: string
-      api_url:
-        description: 'API base URL baked into the app (e.g. http://10.0.2.2:3000 for Android emulator, http://localhost:3000 for iOS Simulator)'
-        required: false
-        default: 'http://10.0.2.2:3000'
-        type: string
 
 concurrency:
   group: mobile-build-${{ github.event.inputs.platform }}
@@ -36,145 +31,59 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # Android — debug APK, runs on any Android emulator, no signing required
-  # ---------------------------------------------------------------------------
-  build-android:
-    name: Android APK (debug)
-    if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'all' }}
+  build:
+    name: EAS Build / ${{ github.event.inputs.platform }}
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
 
       - name: Setup (pnpm + Node + deps)
         uses: ./.github/actions/setup
 
-      - name: Setup Java 17
-        uses: actions/setup-java@v4
+      # Authenticates eas-cli to the Expo account using the EXPO_TOKEN secret.
+      - name: Setup Expo + EAS CLI
+        uses: expo/expo-github-action@v8
         with:
-          java-version: '17'
-          distribution: temurin
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-
-      # Generates the android/ native project from app.json — no native code is
-      # committed to the repo so this must run on every build.
-      # NODE_ENV=production ensures Expo reads app.json correctly during the Gradle build.
-      # --no-install is omitted so post-install hooks (e.g. expo-splash-screen) run fully.
-      - name: Generate Android native project
+      # --wait: block until the remote build completes (default with --json).
+      # Output is a JSON array — one object per platform — each with artifacts.buildUrl.
+      - name: Build with EAS
         working-directory: mobile
-        env:
-          NODE_ENV: production
-          EXPO_PUBLIC_API_URL: ${{ github.event.inputs.api_url }}
-        run: npx expo prebuild --platform android --clean
-
-      - name: Build debug APK
-        working-directory: mobile/android
-        env:
-          NODE_ENV: production
-          EXPO_PUBLIC_API_URL: ${{ github.event.inputs.api_url }}
-        run: ./gradlew assembleDebug
-
-      - name: Collect APK
-        id: apk
         run: |
-          SRC=$(find mobile/android/app/build/outputs/apk/debug -name "*.apk" | head -1)
-          cp "$SRC" app-debug.apk
-          echo "path=app-debug.apk" >> "$GITHUB_OUTPUT"
+          eas build \
+            --platform ${{ github.event.inputs.platform }} \
+            --profile preview \
+            --non-interactive \
+            --json \
+            --wait \
+            > eas-output.json
 
-      - name: Upload APK
+      - name: Download artifacts from EAS
+        run: |
+          mkdir -p artifacts
+          jq -r '.[].artifacts.buildUrl' mobile/eas-output.json | while read -r URL; do
+            [ -z "$URL" ] && continue
+            FILENAME=$(basename "$URL" | cut -d'?' -f1)
+            echo "Downloading $FILENAME"
+            curl -fsSL -o "artifacts/$FILENAME" "$URL"
+          done
+
+      - name: Upload to Actions artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: android-debug-${{ github.run_id }}
-          path: ${{ steps.apk.outputs.path }}
+          name: mobile-preview-${{ github.run_id }}
+          path: artifacts/
           retention-days: 30
           if-no-files-found: error
-
-  # ---------------------------------------------------------------------------
-  # iOS — simulator .app bundle (zipped), no signing required
-  # Install with: xcrun simctl install booted TravelHub.app
-  # ---------------------------------------------------------------------------
-  build-ios:
-    name: iOS Simulator .app
-    if: ${{ github.event.inputs.platform == 'ios' || github.event.inputs.platform == 'all' }}
-    runs-on: macos-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup (pnpm + Node + deps)
-        uses: ./.github/actions/setup
-
-      - name: Generate iOS native project
-        working-directory: mobile
-        env:
-          NODE_ENV: production
-          EXPO_PUBLIC_API_URL: ${{ github.event.inputs.api_url }}
-        run: npx expo prebuild --platform ios --clean --no-install
-
-      - name: Install CocoaPods dependencies
-        working-directory: mobile/ios
-        run: pod install
-
-      # CODE_SIGNING_ALLOWED=NO disables all signing — valid for simulator builds.
-      # EXPO_PUBLIC_API_URL is inherited by Metro when it bundles the JS during the build.
-      - name: Build for iOS Simulator
-        working-directory: mobile
-        env:
-          NODE_ENV: production
-          EXPO_PUBLIC_API_URL: ${{ github.event.inputs.api_url }}
-        run: |
-          xcodebuild \
-            -workspace ios/mobile.xcworkspace \
-            -scheme mobile \
-            -configuration Debug \
-            -sdk iphonesimulator \
-            -derivedDataPath ./build \
-            CODE_SIGNING_ALLOWED=NO \
-            build
-
-      - name: Zip .app bundle
-        run: |
-          APP=$(find mobile/build -name "*.app" -maxdepth 6 | head -1)
-          zip -r mobile.app.zip "$APP"
-
-      - name: Upload simulator app
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios-simulator-${{ github.run_id }}
-          path: mobile.app.zip
-          retention-days: 30
-          if-no-files-found: error
-
-  # ---------------------------------------------------------------------------
-  # Attach artifacts to a GitHub release (only when release_tag is provided)
-  # ---------------------------------------------------------------------------
-  upload-to-release:
-    name: Attach to GitHub Release
-    if: |
-      always() &&
-      github.event.inputs.release_tag != '' &&
-      (needs.build-android.result == 'success' || needs.build-android.result == 'skipped') &&
-      (needs.build-ios.result == 'success' || needs.build-ios.result == 'skipped') &&
-      (needs.build-android.result == 'success' || needs.build-ios.result == 'success')
-    needs: [build-android, build-ios]
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download all build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: release-assets
-          merge-multiple: true
 
       - name: Attach to GitHub release
+        if: ${{ github.event.inputs.release_tag != '' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          for FILE in release-assets/*; do
-            echo "Uploading $(basename "$FILE") to release ${{ github.event.inputs.release_tag }}"
+          for FILE in artifacts/*; do
             gh release upload "${{ github.event.inputs.release_tag }}" "$FILE" \
               --repo "${{ github.repository }}" \
               --clobber

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -97,17 +97,6 @@ jobs:
             fs.writeFileSync('mobile/app.json', JSON.stringify(cfg, null, 2));
           "
 
-      - name: Inject production API URL into eas.json
-        env:
-          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
-        run: |
-          node -e "
-            const fs = require('fs');
-            const eas = JSON.parse(fs.readFileSync('mobile/eas.json', 'utf8'));
-            eas.build.preview.env.EXPO_PUBLIC_API_URL = process.env.EXPO_PUBLIC_API_URL;
-            fs.writeFileSync('mobile/eas.json', JSON.stringify(eas, null, 2));
-          "
-
       - name: Setup Expo + EAS CLI
         uses: expo/expo-github-action@v8
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,4 +1,4 @@
-name: Release Mobile
+name: Publish Release
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
         type: string
 
 concurrency:
-  group: release-mobile
+  group: publish-release
   cancel-in-progress: false
 
 permissions:
@@ -72,9 +72,9 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "Tagged $SHA as $TAG"
 
-  # ── 3a. Build Android debug APK ───────────────────────────────────────────────
-  build-apk:
-    name: Build Android APK
+  # ── 3. Build with EAS (Android APK + iOS Simulator) ───────────────────────────
+  build:
+    name: Build (EAS)
     needs: tag
     runs-on: ubuntu-latest
     steps:
@@ -87,7 +87,6 @@ jobs:
       - name: Set app version in app.json
         run: |
           VERSION="${{ github.event.inputs.version }}"
-          # Strip leading 'v' for the version field (v1.2.3 → 1.2.3)
           SEMVER="${VERSION#v}"
           node -e "
             const fs = require('fs');
@@ -98,97 +97,56 @@ jobs:
             fs.writeFileSync('mobile/app.json', JSON.stringify(cfg, null, 2));
           "
 
-      - name: Setup Java 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: temurin
-
-      - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
-
-      - name: Generate Android native project
-        working-directory: mobile
+      - name: Inject production API URL into eas.json
         env:
-          NODE_ENV: production
           EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
-        run: npx expo prebuild --platform android --clean
-
-      - name: Build debug APK
-        working-directory: mobile/android
-        env:
-          NODE_ENV: production
-          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
-        run: ./gradlew assembleDebug
-
-      - name: Collect APK
         run: |
-          SRC=$(find mobile/android/app/build/outputs/apk/debug -name "*.apk" | head -1)
-          cp "$SRC" travelhub-${{ github.event.inputs.version }}.apk
+          node -e "
+            const fs = require('fs');
+            const eas = JSON.parse(fs.readFileSync('mobile/eas.json', 'utf8'));
+            eas.build.preview.env.EXPO_PUBLIC_API_URL = process.env.EXPO_PUBLIC_API_URL;
+            fs.writeFileSync('mobile/eas.json', JSON.stringify(eas, null, 2));
+          "
 
-      - name: Upload APK artifact
+      - name: Setup Expo + EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build with EAS (Android + iOS)
+        working-directory: mobile
+        run: |
+          eas build \
+            --platform all \
+            --profile preview \
+            --non-interactive \
+            --json \
+            --wait \
+            > eas-output.json
+
+      - name: Download artifacts from EAS
+        run: |
+          mkdir -p artifacts
+
+          ANDROID_URL=$(jq -r '.[] | select(.platform == "ANDROID") | .artifacts.buildUrl' mobile/eas-output.json)
+          IOS_URL=$(jq -r '.[] | select(.platform == "IOS") | .artifacts.buildUrl' mobile/eas-output.json)
+
+          [ -n "$ANDROID_URL" ] && curl -fsSL -o "artifacts/travelhub-${{ github.event.inputs.version }}.apk" "$ANDROID_URL"
+          [ -n "$IOS_URL" ]     && curl -fsSL -o "artifacts/travelhub-${{ github.event.inputs.version }}-ios-simulator.tar.gz" "$IOS_URL"
+
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: travelhub-apk
-          path: travelhub-${{ github.event.inputs.version }}.apk
+          name: travelhub-builds
+          path: artifacts/
           retention-days: 7
-
-  # ── 3b. Build iOS Simulator .app ──────────────────────────────────────────────
-  build-ios:
-    name: Build iOS Simulator
-    needs: tag
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.tag.outputs.sha }}
-
-      - uses: ./.github/actions/setup
-
-      - name: Generate iOS native project
-        working-directory: mobile
-        env:
-          NODE_ENV: production
-          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
-        run: npx expo prebuild --platform ios --clean --no-install
-
-      - name: Install CocoaPods dependencies
-        working-directory: mobile/ios
-        run: pod install
-
-      # CODE_SIGNING_ALLOWED=NO disables all signing — valid for simulator builds.
-      # EXPO_PUBLIC_API_URL is inherited by Metro when it bundles the JS during the build.
-      - name: Build for iOS Simulator
-        working-directory: mobile
-        env:
-          NODE_ENV: production
-          EXPO_PUBLIC_API_URL: ${{ secrets.EXPO_PUBLIC_API_URL }}
-        run: |
-          xcodebuild \
-            -workspace ios/mobile.xcworkspace \
-            -scheme mobile \
-            -configuration Debug \
-            -sdk iphonesimulator \
-            -derivedDataPath ./build \
-            CODE_SIGNING_ALLOWED=NO \
-            build
-
-      - name: Zip .app bundle
-        run: |
-          APP=$(find mobile/build -name "*.app" -maxdepth 6 | head -1)
-          zip -r travelhub-${{ github.event.inputs.version }}-ios-simulator.zip "$APP"
-
-      - name: Upload iOS artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: travelhub-ios-simulator
-          path: travelhub-${{ github.event.inputs.version }}-ios-simulator.zip
-          retention-days: 7
+          if-no-files-found: error
 
   # ── 4. Create GitHub Release ──────────────────────────────────────────────────
   release:
     name: Create release
-    needs: [tag, build-apk, build-ios]
+    needs: [tag, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -196,15 +154,11 @@ jobs:
           ref: ${{ needs.tag.outputs.sha }}
           fetch-depth: 0
 
-      - name: Download APK
+      - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: travelhub-apk
-
-      - name: Download iOS simulator app
-        uses: actions/download-artifact@v4
-        with:
-          name: travelhub-ios-simulator
+          name: travelhub-builds
+          path: artifacts/
 
       - name: Generate changelog
         id: changelog
@@ -220,7 +174,7 @@ jobs:
 
           {
             echo "body<<EOF"
-            echo "## TravelHub Mobile $TAG"
+            echo "## TravelHub $TAG"
             echo ""
             echo "### Changes"
             if [ -n "$COMMITS" ]; then
@@ -235,7 +189,7 @@ jobs:
             echo "adb install travelhub-$TAG.apk"
             echo "\`\`\`"
             echo ""
-            echo "**iOS Simulator:** download \`travelhub-$TAG-ios-simulator.zip\`, unzip, then run:"
+            echo "**iOS Simulator:** download \`travelhub-$TAG-ios-simulator.tar.gz\`, extract, then run:"
             echo "\`\`\`"
             echo "xcrun simctl install booted mobile.app"
             echo "xcrun simctl launch booted com.travelhub.mobile"
@@ -247,10 +201,8 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.version }}
-          name: TravelHub Mobile ${{ github.event.inputs.version }}
+          name: TravelHub ${{ github.event.inputs.version }}
           body: ${{ steps.changelog.outputs.body }}
-          files: |
-            travelhub-${{ github.event.inputs.version }}.apk
-            travelhub-${{ github.event.inputs.version }}-ios-simulator.zip
+          files: artifacts/*
           draft: false
           prerelease: ${{ contains(github.event.inputs.version, '-') }}

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -29,6 +29,7 @@
     },
     "plugins": [
       "expo-router",
+      "./plugins/withCoreSplashscreen",
       [
         "expo-splash-screen",
         {

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -3,10 +3,16 @@
     "version": ">= 16.0.0"
   },
   "build": {
-    "release": {
+    "preview": {
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "http://10.0.2.2:3000"
+      },
       "android": {
-        "buildType": "apk",
-        "gradleCommand": ":app:assembleRelease"
+        "buildType": "apk"
+      },
+      "ios": {
+        "simulator": true
       }
     }
   }

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -5,9 +5,6 @@
   "build": {
     "preview": {
       "distribution": "internal",
-      "env": {
-        "EXPO_PUBLIC_API_URL": "http://10.0.2.2:3000"
-      },
       "android": {
         "buildType": "apk"
       },

--- a/mobile/plugins/withCoreSplashscreen.js
+++ b/mobile/plugins/withCoreSplashscreen.js
@@ -1,0 +1,19 @@
+const { withAppBuildGradle } = require('@expo/config-plugins');
+
+/**
+ * Ensures androidx.core:core-splashscreen is present in android/app/build.gradle.
+ *
+ * expo-splash-screen ~0.29.x generates resources that reference Theme.SplashScreen
+ * and its attributes (windowSplashScreenBackground, etc.) which are defined in
+ * core-splashscreen, but does not always add the dependency itself.
+ */
+module.exports = (config) =>
+  withAppBuildGradle(config, (config) => {
+    if (!config.modResults.contents.includes('core-splashscreen')) {
+      config.modResults.contents = config.modResults.contents.replace(
+        /dependencies \{/,
+        'dependencies {\n    implementation "androidx.core:core-splashscreen:1.0.1"'
+      );
+    }
+    return config;
+  });


### PR DESCRIPTION
## Summary

- Adds `mobile-build.yml` — manual workflow to build Android APK + iOS Simulator app via EAS Build for ad-hoc testing
- Adds `publish-release.yml` (renamed from `release-mobile.yml`) — full release pipeline: validates semver, runs tests, tags commit, builds with EAS, creates GitHub Release with artifacts attached
- Adds `mobile/eas.json` with `preview` profile (Android APK + iOS Simulator)
- Adds `mobile/plugins/withCoreSplashscreen.js` — config plugin that injects `androidx.core:core-splashscreen` into `build.gradle`, fixing a known `expo-splash-screen ~0.29.x` build failure
- Sets `ios.bundleIdentifier` and `android.package` in `mobile/app.json`

## Test plan

- [ ] Add `EXPO_TOKEN` secret (from camilaguayara Expo account) to GitHub repository secrets
- [ ] Trigger `Mobile Build` workflow with `platform: android` — confirm APK appears in Actions artifacts
- [ ] Trigger `Mobile Build` workflow with `platform: ios` — confirm `.tar.gz` appears in Actions artifacts and installs on iOS Simulator
- [ ] Trigger `Publish Release` workflow with a test version (e.g. `v0.1.0`) — confirm tag is created, both artifacts are built, and GitHub Release is created with files attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)