### PR TITLE
ci(mobile): agregar selector de estrategia de build (eas-cloud / github-actions / self-hosted)

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -12,8 +12,18 @@ on:
           - android
           - ios
           - all
+      build_strategy:
+        description: 'Build strategy'
+        required: true
+        type: choice
+        default: eas-cloud
+        options:
+          - eas-cloud
+          - github-actions
+          - self-hosted
+
 concurrency:
-  group: mobile-build-${{ github.event.inputs.platform }}
+  group: mobile-build-${{ github.event.inputs.platform }}-${{ github.ref }}
   cancel-in-progress: false
 
 env:
@@ -23,8 +33,10 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
-  build:
-    name: EAS Build / ${{ github.event.inputs.platform }}
+  # ── Strategy: EAS Cloud ────────────────────────────────────────────────────────
+  build-eas-cloud:
+    if: ${{ github.event.inputs.build_strategy == 'eas-cloud' }}
+    name: EAS Cloud / ${{ github.event.inputs.platform }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,15 +44,12 @@ jobs:
       - name: Setup (pnpm + Node + deps)
         uses: ./.github/actions/setup
 
-      # Authenticates eas-cli to the Expo account using the EXPO_TOKEN secret.
       - name: Setup Expo + EAS CLI
         uses: expo/expo-github-action@v8
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      # --wait: block until the remote build completes (default with --json).
-      # Output is a JSON array — one object per platform — each with artifacts.buildUrl.
       - name: Build with EAS
         working-directory: mobile
         run: |
@@ -70,3 +79,124 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
+  # ── Strategy: GitHub Actions (Android — ubuntu-latest) ────────────────────────
+  build-gh-android:
+    if: ${{ github.event.inputs.build_strategy == 'github-actions' && github.event.inputs.platform != 'ios' }}
+    name: GitHub Actions Local / Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup (pnpm + Node + deps)
+        uses: ./.github/actions/setup
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Expo + EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android (local)
+        working-directory: mobile
+        env:
+          ANDROID_HOME: /usr/local/lib/android/sdk
+        run: |
+          mkdir -p ../artifacts
+          eas build \
+            --platform android \
+            --profile preview \
+            --non-interactive \
+            --local \
+            --output ../artifacts/app.apk
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-preview-android-${{ github.run_id }}
+          path: artifacts/app.apk
+          retention-days: 30
+          if-no-files-found: error
+
+  # ── Strategy: GitHub Actions (iOS — macos-latest) ─────────────────────────────
+  build-gh-ios:
+    if: ${{ github.event.inputs.build_strategy == 'github-actions' && github.event.inputs.platform != 'android' }}
+    name: GitHub Actions Local / iOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup (pnpm + Node + deps)
+        uses: ./.github/actions/setup
+
+      - name: Setup Expo + EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build iOS (local)
+        working-directory: mobile
+        run: |
+          mkdir -p ../artifacts
+          eas build \
+            --platform ios \
+            --profile preview \
+            --non-interactive \
+            --local \
+            --output ../artifacts/app.tar.gz
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-preview-ios-${{ github.run_id }}
+          path: artifacts/app.tar.gz
+          retention-days: 30
+          if-no-files-found: error
+
+  # ── Strategy: Self-hosted (always builds both platforms) ──────────────────────
+  build-self-hosted:
+    if: ${{ github.event.inputs.build_strategy == 'self-hosted' }}
+    name: Self-hosted Local / Android + iOS
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup (pnpm + Node + deps)
+        uses: ./.github/actions/setup
+
+      - name: Setup Expo + EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android + iOS (local)
+        working-directory: mobile
+        run: |
+          mkdir -p ../artifacts
+          eas build \
+            --platform android \
+            --profile preview \
+            --non-interactive \
+            --local \
+            --output ../artifacts/app.apk
+          eas build \
+            --platform ios \
+            --profile preview \
+            --non-interactive \
+            --local \
+            --output ../artifacts/app.tar.gz
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-preview-${{ github.run_id }}
+          path: artifacts/
+          retention-days: 30
+          if-no-files-found: error

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -361,6 +361,7 @@ jobs:
   release:
     name: Create release
     needs: [tag, collect]
+    if: needs.collect.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,15 @@ on:
         description: 'Version tag (e.g. v1.0.0)'
         required: true
         type: string
+      build_strategy:
+        description: 'Build strategy'
+        required: true
+        type: choice
+        default: eas-cloud
+        options:
+          - eas-cloud
+          - github-actions
+          - self-hosted
 
 concurrency:
   group: publish-release
@@ -72,10 +81,11 @@ jobs:
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "Tagged $SHA as $TAG"
 
-  # ── 3. Build with EAS (Android APK + iOS Simulator) ───────────────────────────
-  build:
-    name: Build (EAS)
+  # ── 3a. Build — EAS Cloud ─────────────────────────────────────────────────────
+  build-eas-cloud:
+    name: Build / EAS Cloud
     needs: tag
+    if: ${{ github.event.inputs.build_strategy == 'eas-cloud' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -132,10 +142,225 @@ jobs:
           retention-days: 7
           if-no-files-found: error
 
-  # ── 4. Create GitHub Release ──────────────────────────────────────────────────
+  # ── 3b. Build — GitHub Actions (Android) ──────────────────────────────────────
+  build-gh-android:
+    name: Build / GitHub Actions / Android
+    needs: tag
+    if: ${{ github.event.inputs.build_strategy == 'github-actions' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag.outputs.sha }}
+
+      - uses: ./.github/actions/setup
+
+      - name: Set app version in app.json
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          SEMVER="${VERSION#v}"
+          node -e "
+            const fs = require('fs');
+            const cfg = JSON.parse(fs.readFileSync('mobile/app.json', 'utf8'));
+            cfg.expo.version = '$SEMVER';
+            cfg.expo.android = cfg.expo.android ?? {};
+            cfg.expo.android.versionCode = parseInt('$SEMVER'.replace(/\./g, ''));
+            fs.writeFileSync('mobile/app.json', JSON.stringify(cfg, null, 2));
+          "
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Expo + EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android (local)
+        working-directory: mobile
+        env:
+          ANDROID_HOME: /usr/local/lib/android/sdk
+        run: |
+          mkdir -p ../artifacts
+          eas build \
+            --platform android \
+            --profile preview \
+            --non-interactive \
+            --local \
+            --output "../artifacts/travelhub-${{ github.event.inputs.version }}.apk"
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: travelhub-builds-android
+          path: "artifacts/travelhub-${{ github.event.inputs.version }}.apk"
+          retention-days: 7
+          if-no-files-found: error
+
+  # ── 3c. Build — GitHub Actions (iOS) ──────────────────────────────────────────
+  build-gh-ios:
+    name: Build / GitHub Actions / iOS
+    needs: tag
+    if: ${{ github.event.inputs.build_strategy == 'github-actions' }}
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag.outputs.sha }}
+
+      - uses: ./.github/actions/setup
+
+      - name: Set app version in app.json
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          SEMVER="${VERSION#v}"
+          node -e "
+            const fs = require('fs');
+            const cfg = JSON.parse(fs.readFileSync('mobile/app.json', 'utf8'));
+            cfg.expo.version = '$SEMVER';
+            cfg.expo.android = cfg.expo.android ?? {};
+            cfg.expo.android.versionCode = parseInt('$SEMVER'.replace(/\./g, ''));
+            fs.writeFileSync('mobile/app.json', JSON.stringify(cfg, null, 2));
+          "
+
+      - name: Setup Expo + EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build iOS (local)
+        working-directory: mobile
+        run: |
+          mkdir -p ../artifacts
+          eas build \
+            --platform ios \
+            --profile preview \
+            --non-interactive \
+            --local \
+            --output "../artifacts/travelhub-${{ github.event.inputs.version }}-ios-simulator.tar.gz"
+
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: travelhub-builds-ios
+          path: "artifacts/travelhub-${{ github.event.inputs.version }}-ios-simulator.tar.gz"
+          retention-days: 7
+          if-no-files-found: error
+
+  # ── 3d. Build — Self-hosted (Android + iOS) ───────────────────────────────────
+  build-self-hosted:
+    name: Build / Self-hosted / Android + iOS
+    needs: tag
+    if: ${{ github.event.inputs.build_strategy == 'self-hosted' }}
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.tag.outputs.sha }}
+
+      - uses: ./.github/actions/setup
+
+      - name: Set app version in app.json
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          SEMVER="${VERSION#v}"
+          node -e "
+            const fs = require('fs');
+            const cfg = JSON.parse(fs.readFileSync('mobile/app.json', 'utf8'));
+            cfg.expo.version = '$SEMVER';
+            cfg.expo.android = cfg.expo.android ?? {};
+            cfg.expo.android.versionCode = parseInt('$SEMVER'.replace(/\./g, ''));
+            fs.writeFileSync('mobile/app.json', JSON.stringify(cfg, null, 2));
+          "
+
+      - name: Setup Expo + EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build Android + iOS (local)
+        working-directory: mobile
+        run: |
+          mkdir -p ../artifacts
+          eas build \
+            --platform android \
+            --profile preview \
+            --non-interactive \
+            --local \
+            --output "../artifacts/travelhub-${{ github.event.inputs.version }}.apk"
+          eas build \
+            --platform ios \
+            --profile preview \
+            --non-interactive \
+            --local \
+            --output "../artifacts/travelhub-${{ github.event.inputs.version }}-ios-simulator.tar.gz"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: travelhub-builds
+          path: artifacts/
+          retention-days: 7
+          if-no-files-found: error
+
+  # ── 4. Collect artifacts (fan-in) ─────────────────────────────────────────────
+  collect:
+    name: Collect artifacts
+    needs: [tag, build-eas-cloud, build-gh-android, build-gh-ios, build-self-hosted]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check at least one build succeeded
+        run: |
+          EAS="${{ needs.build-eas-cloud.result }}"
+          GH_A="${{ needs.build-gh-android.result }}"
+          GH_I="${{ needs.build-gh-ios.result }}"
+          SH="${{ needs.build-self-hosted.result }}"
+          if [[ "$EAS" != "success" && "$GH_A" != "success" && "$GH_I" != "success" && "$SH" != "success" ]]; then
+            echo "::error::No build job succeeded. Cannot create release."
+            exit 1
+          fi
+
+      - name: Download EAS Cloud artifacts
+        if: ${{ needs.build-eas-cloud.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: travelhub-builds
+          path: artifacts/
+
+      - name: Download GitHub Actions artifacts
+        if: ${{ needs.build-gh-android.result == 'success' || needs.build-gh-ios.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          pattern: travelhub-builds-*
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Download self-hosted artifacts
+        if: ${{ needs.build-self-hosted.result == 'success' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: travelhub-builds
+          path: artifacts/
+
+      - name: Upload unified artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: travelhub-release-builds
+          path: artifacts/
+          retention-days: 7
+          if-no-files-found: error
+
+  # ── 5. Create GitHub Release ──────────────────────────────────────────────────
   release:
     name: Create release
-    needs: [tag, build]
+    needs: [tag, collect]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -146,7 +371,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: travelhub-builds
+          name: travelhub-release-builds
           path: artifacts/
 
       - name: Generate changelog


### PR DESCRIPTION
## Resumen

- Agrega input `build_strategy` a `mobile-build.yml` y `publish-release.yml` con tres opciones: `eas-cloud`, `github-actions`, `self-hosted`
- Cada estrategia corre en jobs condicionales separados para evitar hacks con `runs-on` dinámico
- Agrega job `collect` como fan-in en `publish-release.yml` para unificar artefactos antes del job `release`
- Corrige skip del job `release` agregando `if: needs.collect.result == 'success'`

## Estrategias

| Estrategia | Runner | Notas |
|---|---|---|
| `eas-cloud` | ubuntu-latest | Build remoto en servidores de Expo (comportamiento anterior) |
| `github-actions` | ubuntu-latest (Android) + macos-latest (iOS) | `eas build --local`, sin cola de EAS |
| `self-hosted` | self-hosted | `eas build --local`, construye Android + iOS en un solo job |

## Test plan

- [ ] Trigger `mobile-build.yml` con cada estrategia y plataforma, verificar que aparecen artefactos en Actions
- [ ] Trigger `publish-release.yml` con cada estrategia, verificar que el GitHub Release se crea con `.apk` y `.tar.gz`
- [ ] Verificar que jobs no seleccionados aparecen como `skipped` y no como `failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)