### PR TITLE
feat(booking): add guestId query filter to GET /reservations

### DIFF
--- a/services/booking-service/src/reservations/reservations.controller.ts
+++ b/services/booking-service/src/reservations/reservations.controller.ts
@@ -5,6 +5,7 @@ import {
   Patch,
   Body,
   Param,
+  Query,
   HttpCode,
   HttpStatus,
 } from "@nestjs/common";
@@ -33,8 +34,8 @@ export class ReservationsController {
   }
 
   @Get()
-  findAll() {
-    return this.reservationsService.findAll();
+  findAll(@Query("guestId") guestId?: string) {
+    return this.reservationsService.findAll(guestId);
   }
 
   @Get(":id")

--- a/services/booking-service/src/reservations/reservations.repository.spec.ts
+++ b/services/booking-service/src/reservations/reservations.repository.spec.ts
@@ -82,6 +82,20 @@ describe("ReservationsRepository", () => {
     });
   });
 
+  describe("findByGuestId", () => {
+    it("filters reservations by guest_id", async () => {
+      const rows = [makeRow()];
+      const db = makeDb({ many: rows });
+      const repo = new ReservationsRepository(db);
+
+      const result = await repo.findByGuestId("guest-uuid");
+
+      expect(db.selectFrom).toHaveBeenCalledWith("reservations");
+      expect(db.where).toHaveBeenCalledWith("guest_id", "=", "guest-uuid");
+      expect(result).toBe(rows);
+    });
+  });
+
   describe("findById", () => {
     it("returns the row when found", async () => {
       const row = makeRow();

--- a/services/booking-service/src/reservations/reservations.repository.ts
+++ b/services/booking-service/src/reservations/reservations.repository.ts
@@ -39,6 +39,14 @@ export class ReservationsRepository {
     return this.db.selectFrom("reservations").selectAll().execute();
   }
 
+  async findByGuestId(guestId: string): Promise<ReservationRow[]> {
+    return this.db
+      .selectFrom("reservations")
+      .where("guest_id", "=", guestId)
+      .selectAll()
+      .execute();
+  }
+
   async findById(id: string): Promise<ReservationRow> {
     const row = await this.db
       .selectFrom("reservations")

--- a/services/booking-service/src/reservations/reservations.service.spec.ts
+++ b/services/booking-service/src/reservations/reservations.service.spec.ts
@@ -58,6 +58,7 @@ describe("ReservationsService", () => {
   let reservationsRepo: {
     insert: jest.Mock;
     findAll: jest.Mock;
+    findByGuestId: jest.Mock;
     findById: jest.Mock;
     toResponse: jest.Mock;
     confirm: jest.Mock;
@@ -75,6 +76,7 @@ describe("ReservationsService", () => {
     reservationsRepo = {
       insert: jest.fn().mockResolvedValue(row),
       findAll: jest.fn().mockResolvedValue([row, row]),
+      findByGuestId: jest.fn().mockResolvedValue([row]),
       findById: jest.fn().mockResolvedValue(row),
       toResponse: jest.fn().mockImplementation((r) => ({ id: r.id })),
       confirm: jest.fn(),
@@ -204,7 +206,6 @@ describe("ReservationsService", () => {
     });
 
     it("filters by guestId when provided", async () => {
-      reservationsRepo.findByGuestId = jest.fn().mockResolvedValue([row]);
       const result = await service.findAll("guest-uuid");
 
       expect(reservationsRepo.findByGuestId).toHaveBeenCalledWith("guest-uuid");

--- a/services/booking-service/src/reservations/reservations.service.spec.ts
+++ b/services/booking-service/src/reservations/reservations.service.spec.ts
@@ -202,6 +202,21 @@ describe("ReservationsService", () => {
 
       expect(reservationsRepo.toResponse).toHaveBeenCalledTimes(2);
     });
+
+    it("filters by guestId when provided", async () => {
+      reservationsRepo.findByGuestId = jest.fn().mockResolvedValue([row]);
+      const result = await service.findAll("guest-uuid");
+
+      expect(reservationsRepo.findByGuestId).toHaveBeenCalledWith("guest-uuid");
+      expect(reservationsRepo.findAll).not.toHaveBeenCalled();
+      expect(result.total).toBe(1);
+    });
+
+    it("returns all when guestId is not provided", async () => {
+      await service.findAll();
+
+      expect(reservationsRepo.findAll).toHaveBeenCalled();
+    });
   });
 
   // ─── findOne ────────────────────────────────────────────────────────────────

--- a/services/booking-service/src/reservations/reservations.service.ts
+++ b/services/booking-service/src/reservations/reservations.service.ts
@@ -68,8 +68,10 @@ export class ReservationsService {
     };
   }
 
-  async findAll() {
-    const rows = await this.reservationsRepo.findAll();
+  async findAll(guestId?: string) {
+    const rows = guestId
+      ? await this.reservationsRepo.findByGuestId(guestId)
+      : await this.reservationsRepo.findAll();
     return {
       total: rows.length,
       reservations: rows.map((r) => this.reservationsRepo.toResponse(r)),


### PR DESCRIPTION
Add optional ?guestId=X query parameter to the GET /reservations endpoint. When provided, returns only reservations for that guest. Without the param, behavior is unchanged (returns all).

- Add findByGuestId() to ReservationsRepository
- Update ReservationsService.findAll() to accept optional guestId
- Add @Query('guestId') to ReservationsController.findAll()