### PR TITLE
feat(mobile): add AuthContext with AsyncStorage persistence

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -7,6 +7,7 @@ import '@/i18n';
 
 import { useColorScheme } from '@/hooks/use-color-scheme';
 import { paperTheme } from '@/constants/paper-theme';
+import { AuthProvider } from '@/context/AuthContext';
 
 export const unstable_settings = {
   anchor: '(tabs)',
@@ -16,6 +17,7 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
+    <AuthProvider>
     <PaperProvider theme={paperTheme}>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <Stack>
@@ -30,5 +32,6 @@ export default function RootLayout() {
         <StatusBar style="auto" />
       </ThemeProvider>
     </PaperProvider>
+    </AuthProvider>
   );
 }

--- a/mobile/context/AuthContext.tsx
+++ b/mobile/context/AuthContext.tsx
@@ -31,16 +31,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   const login = async (newToken: string, newUser: AuthUser) => {
-    await AsyncStorage.multiSet([
-      [TOKEN_KEY, newToken],
-      [USER_KEY, JSON.stringify(newUser)],
+    await Promise.all([
+      AsyncStorage.setItem(TOKEN_KEY, newToken),
+      AsyncStorage.setItem(USER_KEY, JSON.stringify(newUser)),
     ]);
     setToken(newToken);
     setUser(newUser);
   };
 
   const logout = async () => {
-    await AsyncStorage.multiRemove([TOKEN_KEY, USER_KEY]);
+    await Promise.all([
+      AsyncStorage.removeItem(TOKEN_KEY),
+      AsyncStorage.removeItem(USER_KEY),
+    ]);
     setToken(null);
     setUser(null);
   };

--- a/mobile/context/AuthContext.tsx
+++ b/mobile/context/AuthContext.tsx
@@ -1,0 +1,53 @@
+import { useState, useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { AuthContext } from './auth-context';
+import type { AuthUser } from './auth-context';
+
+const TOKEN_KEY = '@auth_token';
+const USER_KEY = '@auth_user';
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const [savedToken, savedUser] = await Promise.all([
+          AsyncStorage.getItem(TOKEN_KEY),
+          AsyncStorage.getItem(USER_KEY),
+        ]);
+        if (savedToken && savedUser) {
+          setToken(savedToken);
+          setUser(JSON.parse(savedUser) as AuthUser);
+        }
+      } catch {
+        // ignore corrupt storage
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, []);
+
+  const login = async (newToken: string, newUser: AuthUser) => {
+    await AsyncStorage.multiSet([
+      [TOKEN_KEY, newToken],
+      [USER_KEY, JSON.stringify(newUser)],
+    ]);
+    setToken(newToken);
+    setUser(newUser);
+  };
+
+  const logout = async () => {
+    await AsyncStorage.multiRemove([TOKEN_KEY, USER_KEY]);
+    setToken(null);
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, user, isLoading, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/mobile/context/auth-context.ts
+++ b/mobile/context/auth-context.ts
@@ -1,0 +1,17 @@
+import { createContext } from 'react';
+
+export type AuthUser = {
+  id: string;
+  email: string;
+  role: string;
+};
+
+export type AuthContextValue = {
+  token: string | null;
+  user: AuthUser | null;
+  isLoading: boolean;
+  login: (token: string, user: AuthUser) => void;
+  logout: () => void;
+};
+
+export const AuthContext = createContext<AuthContextValue | null>(null);

--- a/mobile/hooks/useAuth.spec.ts
+++ b/mobile/hooks/useAuth.spec.ts
@@ -1,0 +1,36 @@
+import React from 'react';
+import { useAuth } from './useAuth';
+import { AuthContext } from '@/context/auth-context';
+import type { AuthContextValue } from '@/context/auth-context';
+
+/* Mock react so we can control useContext */
+const originalUseContext = React.useContext;
+
+afterEach(() => {
+  React.useContext = originalUseContext;
+});
+
+describe('useAuth', () => {
+  it('returns context value when context is provided', () => {
+    const value: AuthContextValue = {
+      token: 'tok',
+      user: { id: '1', email: 'a@b.com', role: 'guest' },
+      isLoading: false,
+      login: jest.fn(),
+      logout: jest.fn(),
+    };
+
+    jest.spyOn(React, 'useContext').mockReturnValue(value);
+
+    const result = useAuth();
+    expect(result.token).toBe('tok');
+    expect(result.user?.email).toBe('a@b.com');
+    expect(React.useContext).toHaveBeenCalledWith(AuthContext);
+  });
+
+  it('throws when used outside AuthProvider', () => {
+    jest.spyOn(React, 'useContext').mockReturnValue(null);
+
+    expect(() => useAuth()).toThrow('useAuth must be used inside AuthProvider');
+  });
+});

--- a/mobile/hooks/useAuth.ts
+++ b/mobile/hooks/useAuth.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { AuthContext } from '@/context/auth-context';
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used inside AuthProvider');
+  return ctx;
+}


### PR DESCRIPTION
Create auth context for the mobile app, mirroring the frontend web pattern but using AsyncStorage instead of localStorage.

- Add auth-context.ts with AuthUser type and context definition
- Add AuthProvider with async token loading from AsyncStorage
- Add useAuth() hook
- Wrap root layout with AuthProvider

Exposes: { token, user, isLoading, login, logout }