### PR TITLE
refactor(booking+payment): máquina de estados completa, ClientsModule y renombrado de estados

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,37 +361,43 @@ Reservations go through the following states:
 ```
 [User clicks Book]
         ↓
-   on_hold  ──(15 min expires)──→  expired
+     held  ──(15 min expires)──→  expired
+        │   ──(user cancel)────→  cancelled
         │
   [payment-service.initiate() called]
         ↓
-    pending  ──(Stripe webhook: payment_failed)──→  (no transition, stays pending — manual retry)
+  submitted  ──(Stripe webhook: payment_intent.payment_failed)──→  failed
+        │    ──(user cancel)────────────────────────────────────→  cancelled
         │
   [Stripe webhook: payment_intent.succeeded]
         ↓
-  confirmed
+  confirmed  ──(user cancel)──→  cancelled
 ```
 
 | Status | Meaning | Inventory hold | Can re-book same room? |
 |---|---|---|---|
-| `on_hold` | User is in checkout, room locked | Active (15-min TTL) | No |
-| `pending` | Payment submitted to Stripe, awaiting webhook | Consumed | Yes |
+| `held` | User is in checkout, room locked | Active (15-min TTL) | No |
+| `submitted` | Payment submitted to Stripe, awaiting webhook | Consumed | Yes |
 | `confirmed` | Webhook fired, booking finalized | Confirmed | No |
 | `expired` | Hold timed out without payment submission | Released | Yes |
+| `failed` | Stripe reported payment failure | Released | Yes |
+| `cancelled` | User cancelled (any non-terminal state) | Released | Yes |
 
 ### Key transitions
 
 | Trigger | From → To | Who calls it |
 |---|---|---|
-| `POST /reservations` | — → `on_hold` | Frontend (via `useBookingFlow`) |
-| `POST /payment/payments/initiate` | `on_hold` → `pending` | payment-service calls `PATCH /reservations/:id/submit` internally |
-| Stripe webhook `payment_intent.succeeded` | `pending` → `confirmed` | payment-service calls `PATCH /reservations/:id/confirm` |
-| Hold expiry job (runs every 60s) | `on_hold` → `expired` | booking-service `HoldExpiryService` |
+| `POST /reservations` | — → `held` | Frontend (via `useBookingFlow`) |
+| `POST /payment/payments/initiate` | `held` → `submitted` | payment-service calls `PATCH /reservations/:id/submit` internally |
+| Stripe webhook `payment_intent.succeeded` | `submitted` → `confirmed` | payment-service calls `PATCH /reservations/:id/confirm` |
+| Stripe webhook `payment_intent.payment_failed` | `submitted` → `failed` | payment-service calls `PATCH /reservations/:id/fail` |
+| `PATCH /reservations/:id/cancel` | any non-terminal → `cancelled` | Frontend/user |
+| Hold expiry job (runs every 60s) | `held` → `expired` | booking-service `HoldExpiryService` |
 
 ### Important notes
-- The partial unique index on reservations only covers `on_hold` rows — a `pending` reservation does **not** block a new hold for the same room/dates.
-- `HoldExpiryService` only expires `on_hold` reservations, not `pending` ones.
-- In local dev without Stripe webhooks configured, reservations stay `pending` after payment. Use the Stripe CLI (`stripe listen --forward-to localhost:3005/payments/webhook`) to test the full flow.
+- The partial unique index on reservations only covers `held` rows — a `submitted` reservation does **not** block a new hold for the same room/dates.
+- `HoldExpiryService` only expires `held` reservations, not `submitted` ones.
+- In local dev without Stripe webhooks configured, reservations stay `submitted` after payment. Use the Stripe CLI (`stripe listen --forward-to localhost:3005/payments/webhook`) to test the full flow.
 
 ## Event Bus (Pub/Sub in GCP, RabbitMQ locally)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -368,10 +368,11 @@ Reservations go through the following states:
         ↓
   submitted  ──(Stripe webhook: payment_intent.payment_failed)──→  failed
         │    ──(user cancel)────────────────────────────────────→  cancelled
-        │
-  [Stripe webhook: payment_intent.succeeded]
-        ↓
-  confirmed  ──(user cancel)──→  cancelled
+        │                                                              │
+  [Stripe webhook: payment_intent.succeeded]                [user retries payment]
+        ↓                                                              │
+  confirmed  ──(user cancel)──→  cancelled                            ↓
+                                                          failed ──(rehold)──→ held (retry)
 ```
 
 | Status | Meaning | Inventory hold | Can re-book same room? |
@@ -388,7 +389,8 @@ Reservations go through the following states:
 | Trigger | From → To | Who calls it |
 |---|---|---|
 | `POST /reservations` | — → `held` | Frontend (via `useBookingFlow`) |
-| `POST /payment/payments/initiate` | `held` → `submitted` | payment-service calls `PATCH /reservations/:id/submit` internally |
+| `POST /payment/payments/initiate` (first attempt) | `held` → `submitted` | payment-service calls `PATCH /reservations/:id/submit` internally |
+| `POST /payment/payments/initiate` (retry) | `failed` → `held` → `submitted` | payment-service calls `PATCH /reservations/:id/rehold` then `PATCH /reservations/:id/submit` |
 | Stripe webhook `payment_intent.succeeded` | `submitted` → `confirmed` | payment-service calls `PATCH /reservations/:id/confirm` |
 | Stripe webhook `payment_intent.payment_failed` | `submitted` → `failed` | payment-service calls `PATCH /reservations/:id/fail` |
 | `PATCH /reservations/:id/cancel` | any non-terminal → `cancelled` | Frontend/user |
@@ -397,6 +399,8 @@ Reservations go through the following states:
 ### Important notes
 - The partial unique index on reservations only covers `held` rows — a `submitted` reservation does **not** block a new hold for the same room/dates.
 - `HoldExpiryService` only expires `held` reservations, not `submitted` ones.
+- A reservation can have **multiple payment rows** (one per attempt). `payments.reservation_id` is not unique. `findByReservationId` returns the most recent row (`ORDER BY created_at DESC`).
+- On payment retry, `initiate()` detects an existing payment row (`isRetry = true`), calls `rehold` to re-acquire inventory, then proceeds with a new Stripe PaymentIntent and a new payment row.
 - In local dev without Stripe webhooks configured, reservations stay `submitted` after payment. Use the Stripe CLI (`stripe listen --forward-to localhost:3005/payments/webhook`) to test the full flow.
 
 ## Event Bus (Pub/Sub in GCP, RabbitMQ locally)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -293,6 +293,7 @@ services:
       PORT: 3005
       DATABASE_URL: postgres://postgres:postgres@payment-db:5432/travelhub?sslmode=disable
       BOOKING_SERVICE_URL: http://booking-service:3004
+      NOTIFICATION_SERVICE_URL: http://notification-service:3006
       SMTP_HOST: ${SMTP_HOST:-}
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_SECURE: ${SMTP_SECURE:-false}

--- a/performance-tests/package.json
+++ b/performance-tests/package.json
@@ -6,6 +6,7 @@
     "test:smoke:booking": "set -a && . ./.env && set +a && k6 run --out json=results/results-booking.json        scenarios/smoke/booking.js",
     "test:load:search":   "set -a && . ./.env && set +a && k6 run --out json=results/results-search-load.json   scenarios/load/search.js",
     "test:load:search:json": "set -a && . ./.env && set +a && k6 run --out json=results/results-search-load-$(date +%Y%m%d-%H%M).json scenarios/load/search.js",
-    "test:all":              "npm run test:smoke:search && npm run test:smoke:booking && npm run test:load:search"
+    "test:all":              "npm run test:smoke:search && npm run test:smoke:booking && npm run test:load:search",
+    "test:smoke:all":        "npm run test:smoke:search && npm run test:smoke:booking"
   }
 }

--- a/performance-tests/scenarios/smoke/booking.js
+++ b/performance-tests/scenarios/smoke/booking.js
@@ -4,9 +4,9 @@
  * Validates functional correctness of the reservation flow:
  *   POST /reservations (held) → PATCH /submit (submitted) → PATCH /confirm (confirmed)
  *   + idempotency (same booker/room/dates returns existing held), double-submit guard,
- *     guest-info update, and hold expiry path.
+ *     guest-info update, cancel from held/submitted, fail + rehold retry path.
  *
- * Each of the 5 scenarios runs exactly once (1 VU × 5 iterations, cycled by __ITER).
+ * Each of the 8 scenarios runs exactly once (1 VU × 8 iterations, cycled by __ITER).
  * Dates are in 2027 — within the seeded rate range (2027-01-01 → 2027-12-31).
  *
  * Usage:
@@ -46,7 +46,7 @@ export const options = {
     booking: {
       executor: "per-vu-iterations",
       vus: 1,
-      iterations: 5,      // one pass per scenario type
+      iterations: 8,      // one pass per scenario type
       maxDuration: "5m",
     },
   },
@@ -109,6 +109,26 @@ function updateGuestInfo(id) {
     { firstName: "Smoke", lastName: "Test", email: "smoke@travelhub.com", phone: "+52 555 000 0000" },
     { name: "update_guest_info" },
   );
+}
+
+function failReservation(id) {
+  return patch(
+    `${BOOKING}/reservations/${id}/fail`,
+    { reason: "Your card was declined." },
+    { name: "fail_reservation" },
+  );
+}
+
+function cancelReservation(id) {
+  return patch(
+    `${BOOKING}/reservations/${id}/cancel`,
+    { reason: "Smoke test cancellation" },
+    { name: "cancel_reservation" },
+  );
+}
+
+function reholdReservation(id) {
+  return patch(`${BOOKING}/reservations/${id}/rehold`, null, { name: "rehold_reservation" });
 }
 
 // ─── Scenarios ────────────────────────────────────────────────────────────────
@@ -241,9 +261,118 @@ function fullLifecycle() {
   });
 }
 
+/**
+ * 5 — Cancel from held
+ * Creates a reservation and cancels it immediately (held → cancelled).
+ * Verifies the reservation reaches the cancelled state and the inventory hold
+ * is released (subsequent create on the same dates should succeed).
+ */
+function cancelHeld() {
+  const { checkIn, checkOut } = datePair();
+
+  const resRes = createReservation(checkIn, checkOut);
+  check(resRes, { "cancel_held: reservation 201": (r) => r.status === 201 });
+  if (resRes.status !== 201) return;
+  const { id } = JSON.parse(resRes.body);
+
+  const cancelRes = cancelReservation(id);
+  check(cancelRes, {
+    "cancel_held: cancel 200":         (r) => r.status === 200,
+    "cancel_held: status cancelled":   (r) => { try { return JSON.parse(r.body).status === "cancelled"; } catch { return false; } },
+    "cancel_held: reason present":     (r) => { try { return !!JSON.parse(r.body).reason; } catch { return false; } },
+  });
+
+  // Inventory should be freed — same dates can be held again
+  const retryRes = createReservation(checkIn, checkOut);
+  check(retryRes, { "cancel_held: room available after cancel": (r) => r.status === 201 });
+  if (retryRes.status === 201) {
+    submitReservation(JSON.parse(retryRes.body).id);
+    confirmReservation(JSON.parse(retryRes.body).id);
+  }
+}
+
+/**
+ * 6 — Cancel from submitted
+ * Creates a reservation, submits it (submitted), then cancels.
+ * Verifies the reservation reaches the cancelled state.
+ */
+function cancelSubmitted() {
+  const { checkIn, checkOut } = datePair();
+
+  const resRes = createReservation(checkIn, checkOut);
+  check(resRes, { "cancel_submitted: reservation 201": (r) => r.status === 201 });
+  if (resRes.status !== 201) return;
+  const { id } = JSON.parse(resRes.body);
+
+  const submitRes = submitReservation(id);
+  check(submitRes, { "cancel_submitted: submit 200": (r) => r.status === 200 });
+
+  const cancelRes = cancelReservation(id);
+  check(cancelRes, {
+    "cancel_submitted: cancel 200":       (r) => r.status === 200,
+    "cancel_submitted: status cancelled": (r) => { try { return JSON.parse(r.body).status === "cancelled"; } catch { return false; } },
+  });
+}
+
+/**
+ * 7 — Fail + rehold + retry to confirmed
+ * Full retry path: held → submitted → failed → held (rehold) → submitted → confirmed.
+ * Verifies the reservation recovers from a failed payment and reaches confirmed.
+ */
+function failAndRetry() {
+  const { checkIn, checkOut } = datePair();
+
+  const resRes = createReservation(checkIn, checkOut);
+  check(resRes, { "fail_retry: reservation 201": (r) => r.status === 201 });
+  if (resRes.status !== 201) return;
+  const { id } = JSON.parse(resRes.body);
+
+  // Transition to submitted
+  const submitRes = submitReservation(id);
+  check(submitRes, { "fail_retry: submit 200": (r) => r.status === 200 });
+  if (submitRes.status !== 200) return;
+
+  // Simulate Stripe payment_failed webhook response
+  const failRes = failReservation(id);
+  check(failRes, {
+    "fail_retry: fail 200":        (r) => r.status === 200,
+    "fail_retry: status failed":   (r) => { try { return JSON.parse(r.body).status === "failed"; } catch { return false; } },
+    "fail_retry: reason present":  (r) => { try { return !!JSON.parse(r.body).reason; } catch { return false; } },
+  });
+  if (failRes.status !== 200) return;
+
+  // Re-acquire inventory hold (failed → held)
+  const reholdRes = reholdReservation(id);
+  check(reholdRes, {
+    "fail_retry: rehold 200":      (r) => r.status === 200,
+    "fail_retry: status held":     (r) => { try { return JSON.parse(r.body).status === "held"; } catch { return false; } },
+    "fail_retry: holdExpiresAt":   (r) => { try { return !!JSON.parse(r.body).holdExpiresAt; } catch { return false; } },
+  });
+  if (reholdRes.status !== 200) return;
+
+  // Retry: submit → confirm
+  const submitRes2 = submitReservation(id);
+  check(submitRes2, { "fail_retry: 2nd submit 200": (r) => r.status === 200 });
+
+  const confirmRes = confirmReservation(id);
+  check(confirmRes, {
+    "fail_retry: confirm 200":      (r) => r.status === 200,
+    "fail_retry: status confirmed": (r) => { try { return JSON.parse(r.body).status === "confirmed"; } catch { return false; } },
+  });
+}
+
 // ─── VU loop ─────────────────────────────────────────────────────────────────
 
-const SCENARIOS = [happyPath, idempotency, getReservationScenario, submitAlreadyPending, fullLifecycle];
+const SCENARIOS = [
+  happyPath,
+  idempotency,
+  getReservationScenario,
+  submitAlreadyPending,
+  fullLifecycle,
+  cancelHeld,
+  cancelSubmitted,
+  failAndRetry,
+];
 
 export default function () {
   SCENARIOS[__ITER % SCENARIOS.length]();

--- a/performance-tests/scenarios/smoke/booking.js
+++ b/performance-tests/scenarios/smoke/booking.js
@@ -1,9 +1,10 @@
 /**
  * TravelHub — Booking Smoke Tests
  *
- * Validates functional correctness of the provisional cart flow:
- *   POST /holds → POST /reservations → PATCH /confirm
- *   + idempotency, double-submit, bad holdId, explicit release
+ * Validates functional correctness of the reservation flow:
+ *   POST /reservations (held) → PATCH /submit (submitted) → PATCH /confirm (confirmed)
+ *   + idempotency (same booker/room/dates returns existing held), double-submit guard,
+ *     guest-info update, and hold expiry path.
  *
  * Each of the 5 scenarios runs exactly once (1 VU × 5 iterations, cycled by __ITER).
  * Dates are in 2027 — within the seeded rate range (2027-01-01 → 2027-12-31).
@@ -18,7 +19,7 @@
 import { check } from "k6";
 import { textSummary } from "https://jslib.k6.io/k6-summary/0.0.2/index.js";
 import { htmlReport } from "https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js";
-import { post, patch, del } from "../../lib/http.js";
+import { post, patch, get } from "../../lib/http.js";
 import { jitter } from "../../lib/utils.js";
 import {
   BOOKING_BOOKER_ID,
@@ -50,9 +51,6 @@ export const options = {
     },
   },
   thresholds: {
-    // All checks must pass at 100% — any unexpected status surfaced here.
-    // http_req_failed is intentionally omitted: bad_hold_id (401) and
-    // release (404) are expected error paths that would inflate the rate.
     checks: ["rate>=1"],
   },
   tags: {
@@ -78,24 +76,14 @@ function datePair() {
   };
 }
 
-function placeHold(checkIn, checkOut) {
-  return post(
-    `${BOOKING}/holds`,
-    { bookerId: BOOKING_BOOKER_ID, roomId: BOOKING_ROOM_ID, checkIn, checkOut },
-    { name: "place_hold" },
-  );
-}
-
-function createReservation(holdId, checkIn, checkOut) {
+function createReservation(checkIn, checkOut) {
   return post(
     `${BOOKING}/reservations`,
     {
-      holdId,
       propertyId: BOOKING_PROPERTY_ID,
       roomId:     BOOKING_ROOM_ID,
       partnerId:  BOOKING_PARTNER_ID,
       bookerId:   BOOKING_BOOKER_ID,
-      guestInfo:  { firstName: "Smoke", lastName: "Test", email: "smoke@travelhub.com" },
       checkIn,
       checkOut,
     },
@@ -103,37 +91,56 @@ function createReservation(holdId, checkIn, checkOut) {
   );
 }
 
+function submitReservation(id) {
+  return patch(`${BOOKING}/reservations/${id}/submit`, null, { name: "submit_reservation" });
+}
+
 function confirmReservation(id) {
   return patch(`${BOOKING}/reservations/${id}/confirm`, null, { name: "confirm_reservation" });
+}
+
+function getReservation(id) {
+  return get(`${BOOKING}/reservations/${id}`, { name: "get_reservation" });
+}
+
+function updateGuestInfo(id) {
+  return patch(
+    `${BOOKING}/reservations/${id}/guest-info`,
+    { firstName: "Smoke", lastName: "Test", email: "smoke@travelhub.com", phone: "+52 555 000 0000" },
+    { name: "update_guest_info" },
+  );
 }
 
 // ─── Scenarios ────────────────────────────────────────────────────────────────
 
 /**
  * 0 — Happy path
- * Full flow: hold → reserve → confirm.
+ * Full flow: create (held) → guest-info → submit (submitted) → confirm (confirmed).
  * Verifies HTTP statuses and response shape at each step.
  */
 function happyPath() {
   const { checkIn, checkOut } = datePair();
 
-  const holdRes = placeHold(checkIn, checkOut);
-  const holdOk = check(holdRes, {
-    "happy_path: hold 201":          (r) => r.status === 201,
-    "happy_path: holdId present":    (r) => { try { return !!JSON.parse(r.body).holdId; } catch { return false; } },
-    "happy_path: expiresAt present": (r) => { try { return !!JSON.parse(r.body).expiresAt; } catch { return false; } },
-  });
-  if (!holdOk || holdRes.status !== 201) return;
-  const { holdId } = JSON.parse(holdRes.body);
-
-  const resRes = createReservation(holdId, checkIn, checkOut);
+  const resRes = createReservation(checkIn, checkOut);
   const resOk = check(resRes, {
-    "happy_path: reservation 201":          (r) => r.status === 201,
-    "happy_path: fareBreakdown present":    (r) => { try { return !!JSON.parse(r.body).fareBreakdown; } catch { return false; } },
-    "happy_path: holdExpiresAt present":    (r) => { try { return !!JSON.parse(r.body).holdExpiresAt; } catch { return false; } },
+    "happy_path: reservation 201":       (r) => r.status === 201,
+    "happy_path: status held":            (r) => { try { return JSON.parse(r.body).status === "held"; } catch { return false; } },
+    "happy_path: fareBreakdown present": (r) => { try { return !!JSON.parse(r.body).fareBreakdown; } catch { return false; } },
+    "happy_path: holdExpiresAt present": (r) => { try { return !!JSON.parse(r.body).holdExpiresAt; } catch { return false; } },
   });
   if (!resOk || resRes.status !== 201) return;
   const { id } = JSON.parse(resRes.body);
+
+  const patchRes = updateGuestInfo(id);
+  check(patchRes, {
+    "happy_path: guest-info 200": (r) => r.status === 200,
+  });
+
+  const submitRes = submitReservation(id);
+  check(submitRes, {
+    "happy_path: submit 200":       (r) => r.status === 200,
+    "happy_path: status submitted":  (r) => { try { return JSON.parse(r.body).status === "submitted"; } catch { return false; } },
+  });
 
   const confirmRes = confirmReservation(id);
   check(confirmRes, {
@@ -143,104 +150,100 @@ function happyPath() {
 }
 
 /**
- * 1 — Idempotency (double-click on "Select Room")
- * Two POST /holds with the same params must return the same holdId.
- * inventory held_rooms must not be double-incremented.
- * Releases the hold at the end to keep inventory clean.
+ * 1 — Idempotency (double-click on "Book")
+ * Two POST /reservations with the same booker/room/dates return the same reservation ID.
+ * The partial unique index on held prevents duplicate active holds.
  */
 function idempotency() {
   const { checkIn, checkOut } = datePair();
 
-  const r1 = placeHold(checkIn, checkOut);
-  check(r1, { "idempotency: 1st hold 201": (r) => r.status === 201 });
+  const r1 = createReservation(checkIn, checkOut);
+  check(r1, { "idempotency: 1st reservation 201": (r) => r.status === 201 });
   if (r1.status !== 201) return;
-  const holdId1 = JSON.parse(r1.body).holdId;
+  const id1 = JSON.parse(r1.body).id;
 
-  const r2 = placeHold(checkIn, checkOut); // identical params
-  const holdId2 = r2.status < 300 ? JSON.parse(r2.body).holdId : null;
+  const r2 = createReservation(checkIn, checkOut); // identical params
+  const id2 = (r2.status === 200 || r2.status === 201) ? JSON.parse(r2.body).id : null;
   check(r2, {
-    "idempotency: 2nd hold is 2xx":         (r) => r.status >= 200 && r.status < 300,
-    "idempotency: same holdId returned":    () => holdId1 === holdId2,
+    "idempotency: 2nd call is 2xx":       (r) => r.status >= 200 && r.status < 300,
+    "idempotency: same reservation id":   () => id1 === id2,
   });
 
-  // Cleanup — release hold so inventory held_rooms returns to 0
-  del(`${BOOKING}/holds/${holdId1}`, { name: "release_hold" });
+  // Cleanup — confirm so the held is released
+  submitReservation(id1);
+  confirmReservation(id1);
 }
 
 /**
- * 2 — Double-submit protection
- * Two POST /reservations with the same holdId: first succeeds (201),
- * second is rejected (410 Gone) — GETDEL atomicity ensures one winner.
+ * 2 — Get reservation
+ * Creates a reservation and fetches it by ID.
+ * Verifies the response shape and status.
  */
-function doubleSubmit() {
+function getReservationScenario() {
   const { checkIn, checkOut } = datePair();
 
-  const holdRes = placeHold(checkIn, checkOut);
-  if (holdRes.status !== 201) return;
-  const { holdId } = JSON.parse(holdRes.body);
+  const resRes = createReservation(checkIn, checkOut);
+  if (resRes.status !== 201) return;
+  const { id } = JSON.parse(resRes.body);
 
-  const r1 = createReservation(holdId, checkIn, checkOut);
-  check(r1, { "double_submit: 1st reservation 201": (r) => r.status === 201 });
-  if (r1.status !== 201) return;
-  const { id } = JSON.parse(r1.body);
+  const getRes = getReservation(id);
+  check(getRes, {
+    "get_reservation: 200":              (r) => r.status === 200,
+    "get_reservation: id matches":       (r) => { try { return JSON.parse(r.body).id === id; } catch { return false; } },
+    "get_reservation: status held":       (r) => { try { return JSON.parse(r.body).status === "held"; } catch { return false; } },
+  });
 
-  const r2 = createReservation(holdId, checkIn, checkOut); // same holdId, hold already consumed
-  check(r2, { "double_submit: 2nd reservation 410": (r) => r.status === 410 });
+  // Cleanup
+  submitReservation(id);
+  confirmReservation(id);
+}
+
+/**
+ * 3 — Submit without prior held (idempotency guard)
+ * Submitting an already-submitted or confirmed reservation returns 404.
+ */
+function submitAlreadyPending() {
+  const { checkIn, checkOut } = datePair();
+
+  const resRes = createReservation(checkIn, checkOut);
+  if (resRes.status !== 201) return;
+  const { id } = JSON.parse(resRes.body);
+
+  // First submit: ok
+  const s1 = submitReservation(id);
+  check(s1, { "double_submit: 1st submit 200": (r) => r.status === 200 });
+
+  // Second submit on already-submitted: rejected (404 — not held anymore)
+  const s2 = submitReservation(id);
+  check(s2, { "double_submit: 2nd submit rejected": (r) => r.status === 404 || r.status === 409 || r.status === 400 });
 
   // Cleanup
   confirmReservation(id);
 }
 
 /**
- * 3 — Bad holdId
- * POST /reservations with a holdId that doesn't match the Redis payload
- * must be rejected with 401 Unauthorized.
- * Releases the real hold at the end.
+ * 4 — Full lifecycle check
+ * Creates, submits, confirms and verifies final state via GET.
  */
-function badHoldId() {
+function fullLifecycle() {
   const { checkIn, checkOut } = datePair();
 
-  const holdRes = placeHold(checkIn, checkOut);
-  if (holdRes.status !== 201) return;
-  const { holdId } = JSON.parse(holdRes.body);
+  const resRes = createReservation(checkIn, checkOut);
+  if (resRes.status !== 201) return;
+  const { id } = JSON.parse(resRes.body);
 
-  const r = createReservation(
-    "00000000-0000-0000-0000-000000000000", // wrong holdId
-    checkIn,
-    checkOut,
-  );
-  check(r, { "bad_hold_id: 401 Unauthorized": (r) => r.status === 401 });
+  submitReservation(id);
+  confirmReservation(id);
 
-  // Cleanup — Redis idempotency key is still alive (GETDEL reads the key
-  // before validating the holdId mismatch, so the key is consumed).
-  // Nothing to release — the hold in inventory is still active but the
-  // idempotency key is gone. Release via by-id key.
-  del(`${BOOKING}/holds/${holdId}`, { name: "release_hold" });
-}
-
-/**
- * 4 — Explicit release
- * DELETE /holds/:holdId returns 204 on the first call.
- * A second DELETE on the same holdId returns 404 (already released).
- */
-function releaseHold() {
-  const { checkIn, checkOut } = datePair();
-
-  const holdRes = placeHold(checkIn, checkOut);
-  check(holdRes, { "release: hold 201": (r) => r.status === 201 });
-  if (holdRes.status !== 201) return;
-  const { holdId } = JSON.parse(holdRes.body);
-
-  const r1 = del(`${BOOKING}/holds/${holdId}`, { name: "release_hold" });
-  check(r1, { "release: DELETE 204": (r) => r.status === 204 });
-
-  const r2 = del(`${BOOKING}/holds/${holdId}`, { name: "release_hold" });
-  check(r2, { "release: 2nd DELETE 404": (r) => r.status === 404 });
+  const getRes = getReservation(id);
+  check(getRes, {
+    "lifecycle: final status confirmed": (r) => { try { return JSON.parse(r.body).status === "confirmed"; } catch { return false; } },
+  });
 }
 
 // ─── VU loop ─────────────────────────────────────────────────────────────────
 
-const SCENARIOS = [happyPath, idempotency, doubleSubmit, badHoldId, releaseHold];
+const SCENARIOS = [happyPath, idempotency, getReservationScenario, submitAlreadyPending, fullLifecycle];
 
 export default function () {
   SCENARIOS[__ITER % SCENARIOS.length]();

--- a/services/booking-service/scripts/seed.ts
+++ b/services/booking-service/scripts/seed.ts
@@ -301,7 +301,7 @@ const RESERVATIONS = [
     grand_total_usd: 978.9,
     hold_expires_at: new Date("2026-04-10T09:00:00.000Z"),
   },
-  // ── pending — Hostal Sol Cancún, Standard Double (room 6), 3 nights @ $60 ──
+  // ── submitted — Hostal Sol Cancún, Standard Double (room 6), 3 nights @ $60 ──
   // Hold placed just now via POST /holds; reservation submitted immediately after.
   // hold_expires_at mirrors the Redis TTL so the sweeper fires at the right moment.
   {
@@ -313,7 +313,7 @@ const RESERVATIONS = [
     guest_info: GUEST_INFO[2],
     check_in: "2027-05-10",
     check_out: "2027-05-13",
-    status: "pending",
+    status: "submitted",
     fare_breakdown: {
       nights: 3,
       roomRateUsd: 60,

--- a/services/booking-service/src/database/database.types.ts
+++ b/services/booking-service/src/database/database.types.ts
@@ -84,6 +84,11 @@ export interface ReservationsTable {
     Date | null | undefined,
     Date | null | undefined
   >;
+  reason: ColumnType<
+    string | null,
+    string | null | undefined,
+    string | null | undefined
+  >;
   created_at: Generated<Date>;
   updated_at: Generated<Date>;
 }

--- a/services/booking-service/src/database/migrations/20260424_003_add_reason.ts
+++ b/services/booking-service/src/database/migrations/20260424_003_add_reason.ts
@@ -1,0 +1,18 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+// Adds a `reason` TEXT column to reservations to capture context for terminal
+// states — `failed` (system-driven, e.g. payment failure) and `cancelled`
+// (user-initiated). Nullable: only populated when the reservation terminates
+// with an explicit reason.
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE reservations ADD COLUMN reason TEXT
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE reservations DROP COLUMN reason
+  `.execute(db);
+}

--- a/services/booking-service/src/database/migrations/20260424_004_rename_statuses.ts
+++ b/services/booking-service/src/database/migrations/20260424_004_rename_statuses.ts
@@ -1,0 +1,19 @@
+import { Kysely, sql } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE reservations SET status = 'submitted' WHERE status = 'pending'`.execute(
+    db,
+  );
+  await sql`UPDATE reservations SET status = 'held' WHERE status = 'on_hold'`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`UPDATE reservations SET status = 'on_hold' WHERE status = 'held'`.execute(
+    db,
+  );
+  await sql`UPDATE reservations SET status = 'pending' WHERE status = 'submitted'`.execute(
+    db,
+  );
+}

--- a/services/booking-service/src/database/migrations/20260424_005_fix_held_unique_idx.ts
+++ b/services/booking-service/src/database/migrations/20260424_005_fix_held_unique_idx.ts
@@ -1,0 +1,30 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+// Migration 001 created reservations_pending_booker_room_stay_idx with
+// WHERE status = 'pending'. After migration 004 renamed that status to
+// 'held', the index no longer covers any rows. Drop and recreate it
+// pointing at the new status name so the idempotency guard still works.
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    DROP INDEX IF EXISTS reservations_pending_booker_room_stay_idx
+  `.execute(db);
+
+  await sql`
+    CREATE UNIQUE INDEX reservations_held_booker_room_stay_idx
+      ON reservations (booker_id, room_id, check_in, check_out)
+      WHERE status = 'held'
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`
+    DROP INDEX IF EXISTS reservations_held_booker_room_stay_idx
+  `.execute(db);
+
+  await sql`
+    CREATE UNIQUE INDEX reservations_pending_booker_room_stay_idx
+      ON reservations (booker_id, room_id, check_in, check_out)
+      WHERE status = 'pending'
+  `.execute(db);
+}

--- a/services/booking-service/src/reservations/hold-expiry.service.spec.ts
+++ b/services/booking-service/src/reservations/hold-expiry.service.spec.ts
@@ -9,7 +9,7 @@ function makeRow(overrides: Record<string, unknown> = {}) {
     room_id: "room-uuid",
     check_in: "2026-05-01",
     check_out: "2026-05-04",
-    status: "pending",
+    status: "held",
     ...overrides,
   };
 }

--- a/services/booking-service/src/reservations/reservations.controller.spec.ts
+++ b/services/booking-service/src/reservations/reservations.controller.spec.ts
@@ -52,6 +52,9 @@ describe("ReservationsController", () => {
             findOne: jest.fn(),
             submit: jest.fn(),
             confirm: jest.fn(),
+            fail: jest.fn(),
+            cancel: jest.fn(),
+            rehold: jest.fn(),
             updateGuestInfo: jest.fn(),
           },
         },
@@ -180,6 +183,46 @@ describe("ReservationsController", () => {
       const result = await controller.updateGuestInfo("res-1", dto as any);
 
       expect(service.updateGuestInfo).toHaveBeenCalledWith("res-1", dto);
+      expect(result).toBe(reservation);
+    });
+  });
+
+  describe("fail", () => {
+    it("delegates to service with id and reason", async () => {
+      const reservation = { id: "res-1", status: "failed" } as any;
+      (service.fail as jest.Mock).mockResolvedValue(reservation);
+
+      const result = await controller.fail("res-1", {
+        reason: "card declined",
+      });
+
+      expect(service.fail).toHaveBeenCalledWith("res-1", "card declined");
+      expect(result).toBe(reservation);
+    });
+  });
+
+  describe("cancel", () => {
+    it("delegates to service with id and reason", async () => {
+      const reservation = { id: "res-1", status: "cancelled" } as any;
+      (service.cancel as jest.Mock).mockResolvedValue(reservation);
+
+      const result = await controller.cancel("res-1", {
+        reason: "changed mind",
+      });
+
+      expect(service.cancel).toHaveBeenCalledWith("res-1", "changed mind");
+      expect(result).toBe(reservation);
+    });
+  });
+
+  describe("rehold", () => {
+    it("delegates to service and returns the reheld reservation", async () => {
+      const reservation = { id: "res-1", status: "held" } as any;
+      (service.rehold as jest.Mock).mockResolvedValue(reservation);
+
+      const result = await controller.rehold("res-1");
+
+      expect(service.rehold).toHaveBeenCalledWith("res-1");
       expect(result).toBe(reservation);
     });
   });

--- a/services/booking-service/src/reservations/reservations.controller.spec.ts
+++ b/services/booking-service/src/reservations/reservations.controller.spec.ts
@@ -50,7 +50,7 @@ describe("ReservationsController", () => {
             create: jest.fn(),
             findAll: jest.fn(),
             findOne: jest.fn(),
-            submitPayment: jest.fn(),
+            submit: jest.fn(),
             confirm: jest.fn(),
             updateGuestInfo: jest.fn(),
           },
@@ -143,14 +143,14 @@ describe("ReservationsController", () => {
     });
   });
 
-  describe("submitPayment", () => {
-    it("delegates to service and returns the pending reservation", async () => {
-      const reservation = { id: "res-1", status: "pending" } as any;
-      (service.submitPayment as jest.Mock).mockResolvedValue(reservation);
+  describe("submit", () => {
+    it("delegates to service and returns the submitted reservation", async () => {
+      const reservation = { id: "res-1", status: "submitted" } as any;
+      (service.submit as jest.Mock).mockResolvedValue(reservation);
 
-      const result = await controller.submitPayment("res-1");
+      const result = await controller.submit("res-1");
 
-      expect(service.submitPayment).toHaveBeenCalledWith("res-1");
+      expect(service.submit).toHaveBeenCalledWith("res-1");
       expect(result).toBe(reservation);
     });
   });

--- a/services/booking-service/src/reservations/reservations.controller.ts
+++ b/services/booking-service/src/reservations/reservations.controller.ts
@@ -69,6 +69,12 @@ export class ReservationsController {
     return this.reservationsService.cancel(id, body.reason);
   }
 
+  @Patch(":id/rehold")
+  @HttpCode(HttpStatus.OK)
+  rehold(@Param("id") id: string) {
+    return this.reservationsService.rehold(id);
+  }
+
   @Patch(":id/confirm")
   @HttpCode(HttpStatus.OK)
   confirm(@Param("id") id: string) {

--- a/services/booking-service/src/reservations/reservations.controller.ts
+++ b/services/booking-service/src/reservations/reservations.controller.ts
@@ -53,8 +53,20 @@ export class ReservationsController {
 
   @Patch(":id/submit")
   @HttpCode(HttpStatus.OK)
-  submitPayment(@Param("id") id: string) {
-    return this.reservationsService.submitPayment(id);
+  submit(@Param("id") id: string) {
+    return this.reservationsService.submit(id);
+  }
+
+  @Patch(":id/fail")
+  @HttpCode(HttpStatus.OK)
+  fail(@Param("id") id: string, @Body() body: { reason: string }) {
+    return this.reservationsService.fail(id, body.reason);
+  }
+
+  @Patch(":id/cancel")
+  @HttpCode(HttpStatus.OK)
+  cancel(@Param("id") id: string, @Body() body: { reason: string }) {
+    return this.reservationsService.cancel(id, body.reason);
   }
 
   @Patch(":id/confirm")

--- a/services/booking-service/src/reservations/reservations.repository.spec.ts
+++ b/services/booking-service/src/reservations/reservations.repository.spec.ts
@@ -46,7 +46,7 @@ function makeRow(overrides: Record<string, unknown> = {}) {
     },
     check_in: "2026-05-01",
     check_out: "2026-05-04",
-    status: "on_hold",
+    status: "held",
     fare_breakdown: { total: 522 },
     tax_total_usd: "72.00",
     fee_total_usd: "0.00",
@@ -147,7 +147,7 @@ describe("ReservationsRepository", () => {
       });
       expect(result.checkIn).toBe("2026-05-01");
       expect(result.checkOut).toBe("2026-05-04");
-      expect(result.status).toBe("on_hold");
+      expect(result.status).toBe("held");
     });
 
     it("parses numeric columns as floats", () => {
@@ -228,7 +228,7 @@ describe("ReservationsRepository", () => {
       expect(result).toEqual(confirmed);
     });
 
-    it("guards against confirming non-pending rows via status filter", async () => {
+    it("guards against confirming non-submitted rows via status filter", async () => {
       const db = makeDb({ single: undefined });
       const repo = new ReservationsRepository(db);
 
@@ -248,15 +248,15 @@ describe("ReservationsRepository", () => {
   });
 
   describe("findExpiredHolds", () => {
-    it("returns on_hold rows with hold_expires_at in the past", async () => {
-      const rows = [makeRow({ status: "on_hold" })];
+    it("returns held rows with hold_expires_at in the past", async () => {
+      const rows = [makeRow({ status: "held" })];
       const db = makeDb({ many: rows });
       const repo = new ReservationsRepository(db);
 
       const result = await repo.findExpiredHolds();
 
       expect(db.selectFrom).toHaveBeenCalledWith("reservations");
-      expect(db.where).toHaveBeenCalledWith("status", "=", "on_hold");
+      expect(db.where).toHaveBeenCalledWith("status", "=", "held");
       expect(db.where).toHaveBeenCalledWith(
         "hold_expires_at",
         "<",
@@ -266,13 +266,13 @@ describe("ReservationsRepository", () => {
     });
   });
 
-  describe("findPendingByBookerAndStay", () => {
-    it("returns the row when a matching on_hold reservation exists", async () => {
+  describe("findHoldByBookerAndStay", () => {
+    it("returns the row when a matching held reservation exists", async () => {
       const row = makeRow();
       const db = makeDb({ single: row });
       const repo = new ReservationsRepository(db);
 
-      const result = await repo.findPendingByBookerAndStay(
+      const result = await repo.findHoldByBookerAndStay(
         "booker-uuid",
         "room-uuid",
         "2026-05-01",
@@ -284,15 +284,15 @@ describe("ReservationsRepository", () => {
       expect(db.where).toHaveBeenCalledWith("room_id", "=", "room-uuid");
       expect(db.where).toHaveBeenCalledWith("check_in", "=", "2026-05-01");
       expect(db.where).toHaveBeenCalledWith("check_out", "=", "2026-05-04");
-      expect(db.where).toHaveBeenCalledWith("status", "=", "on_hold");
+      expect(db.where).toHaveBeenCalledWith("status", "=", "held");
       expect(result).toBe(row);
     });
 
-    it("returns null when no matching pending reservation exists", async () => {
+    it("returns null when no matching held reservation exists", async () => {
       const db = makeDb({ single: undefined });
       const repo = new ReservationsRepository(db);
 
-      const result = await repo.findPendingByBookerAndStay(
+      const result = await repo.findHoldByBookerAndStay(
         "booker-uuid",
         "room-uuid",
         "2026-05-01",
@@ -341,27 +341,25 @@ describe("ReservationsRepository", () => {
     });
   });
 
-  describe("submitPayment", () => {
-    it("transitions status from on_hold to pending and returns the updated row", async () => {
-      const pending = makeRow({ status: "pending" });
-      const db = makeDb({ single: pending });
+  describe("submit", () => {
+    it("transitions status from held to submitted and returns the updated row", async () => {
+      const submitted = makeRow({ status: "submitted" });
+      const db = makeDb({ single: submitted });
       const repo = new ReservationsRepository(db);
 
-      const result = await repo.submitPayment("res-uuid");
+      const result = await repo.submit("res-uuid");
 
       expect(db.updateTable).toHaveBeenCalledWith("reservations");
       expect(db.where).toHaveBeenCalledWith("id", "=", "res-uuid");
-      expect(db.where).toHaveBeenCalledWith("status", "=", "on_hold");
-      expect(result).toBe(pending);
+      expect(db.where).toHaveBeenCalledWith("status", "=", "held");
+      expect(result).toBe(submitted);
     });
 
-    it("throws NotFoundException when reservation not found or not on_hold", async () => {
+    it("throws NotFoundException when reservation not found or not held", async () => {
       const db = makeDb({ single: undefined });
       const repo = new ReservationsRepository(db);
 
-      await expect(repo.submitPayment("res-uuid")).rejects.toThrow(
-        NotFoundException,
-      );
+      await expect(repo.submit("res-uuid")).rejects.toThrow(NotFoundException);
     });
   });
 
@@ -375,11 +373,11 @@ describe("ReservationsRepository", () => {
 
       expect(db.updateTable).toHaveBeenCalledWith("reservations");
       expect(db.where).toHaveBeenCalledWith("id", "=", "res-uuid");
-      expect(db.where).toHaveBeenCalledWith("status", "=", "on_hold");
+      expect(db.where).toHaveBeenCalledWith("status", "=", "held");
       expect(result).toBe(expired);
     });
 
-    it("returns undefined when row is not pending (idempotency guard)", async () => {
+    it("returns undefined when row is not held (idempotency guard)", async () => {
       const db = makeDb({ single: undefined });
       const repo = new ReservationsRepository(db);
 

--- a/services/booking-service/src/reservations/reservations.repository.spec.ts
+++ b/services/booking-service/src/reservations/reservations.repository.spec.ts
@@ -386,4 +386,142 @@ describe("ReservationsRepository", () => {
       expect(result).toBeUndefined();
     });
   });
+
+  describe("fail", () => {
+    it("transitions status from submitted to failed and returns the row", async () => {
+      const failed = makeRow({ status: "failed", reason: "card declined" });
+      const db = makeDb({ single: failed });
+      const repo = new ReservationsRepository(db);
+
+      const result = await repo.fail("res-uuid", "card declined");
+
+      expect(db.updateTable).toHaveBeenCalledWith("reservations");
+      expect(db.where).toHaveBeenCalledWith("id", "=", "res-uuid");
+      expect(db.where).toHaveBeenCalledWith("status", "=", "submitted");
+      expect(result).toBe(failed);
+    });
+
+    it("throws NotFoundException when reservation not found or not submitted", async () => {
+      const db = makeDb({ single: undefined });
+      const repo = new ReservationsRepository(db);
+
+      await expect(repo.fail("res-uuid", "card declined")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe("rehold", () => {
+    it("transitions status from failed to held and updates hold_expires_at", async () => {
+      const expiresAt = new Date(Date.now() + 900_000);
+      const reheld = makeRow({ status: "held", hold_expires_at: expiresAt });
+      const db = makeDb({ single: reheld });
+      const repo = new ReservationsRepository(db);
+
+      const result = await repo.rehold("res-uuid", expiresAt);
+
+      expect(db.updateTable).toHaveBeenCalledWith("reservations");
+      expect(db.where).toHaveBeenCalledWith("id", "=", "res-uuid");
+      expect(db.where).toHaveBeenCalledWith("status", "=", "failed");
+      expect(result).toBe(reheld);
+    });
+
+    it("throws NotFoundException when reservation not found or not failed", async () => {
+      const db = makeDb({ single: undefined });
+      const repo = new ReservationsRepository(db);
+
+      await expect(repo.rehold("res-uuid", new Date())).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe("cancel", () => {
+    function makeDbForCancel(
+      opts: {
+        currentStatus?: string | null;
+        cancelledRow?: Record<string, unknown>;
+      } = {},
+    ) {
+      const trx: Record<string, jest.Mock> = {};
+      const chain = [
+        "selectFrom",
+        "updateTable",
+        "set",
+        "where",
+        "select",
+        "selectAll",
+        "returningAll",
+        "forUpdate",
+      ];
+      chain.forEach((m) => {
+        trx[m] = jest.fn().mockReturnValue(trx);
+      });
+      trx.executeTakeFirst = jest
+        .fn()
+        .mockResolvedValue(
+          opts.currentStatus != null
+            ? { status: opts.currentStatus }
+            : undefined,
+        );
+      trx.executeTakeFirstOrThrow = jest
+        .fn()
+        .mockResolvedValue(
+          opts.cancelledRow ?? makeRow({ status: "cancelled" }),
+        );
+
+      const db = {
+        transaction: jest.fn().mockReturnValue({
+          execute: jest
+            .fn()
+            .mockImplementation((fn: (trx: unknown) => unknown) => fn(trx)),
+        }),
+      };
+      return db as any;
+    }
+
+    it("returns the cancelled row and prior status", async () => {
+      const cancelled = makeRow({
+        status: "cancelled",
+        reason: "changed mind",
+      });
+      const db = makeDbForCancel({
+        currentStatus: "held",
+        cancelledRow: cancelled,
+      });
+      const repo = new ReservationsRepository(db);
+
+      const result = await repo.cancel("res-uuid", "changed mind");
+
+      expect(result.row).toBe(cancelled);
+      expect(result.priorStatus).toBe("held");
+    });
+
+    it("throws NotFoundException when reservation does not exist", async () => {
+      const db = makeDbForCancel({ currentStatus: null });
+      const repo = new ReservationsRepository(db);
+
+      await expect(repo.cancel("res-uuid", "changed mind")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("throws NotFoundException when reservation is already terminal (cancelled)", async () => {
+      const db = makeDbForCancel({ currentStatus: "cancelled" });
+      const repo = new ReservationsRepository(db);
+
+      await expect(repo.cancel("res-uuid", "re-cancel")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("throws NotFoundException when reservation is already terminal (expired)", async () => {
+      const db = makeDbForCancel({ currentStatus: "expired" });
+      const repo = new ReservationsRepository(db);
+
+      await expect(repo.cancel("res-uuid", "too late")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
 });

--- a/services/booking-service/src/reservations/reservations.repository.ts
+++ b/services/booking-service/src/reservations/reservations.repository.ts
@@ -17,6 +17,7 @@ export interface ReservationResponse {
   checkIn: string;
   checkOut: string;
   status: string;
+  reason: string | null;
   fareBreakdown: unknown;
   taxTotalUsd: number | null;
   feeTotalUsd: number | null;
@@ -63,17 +64,17 @@ export class ReservationsRepository {
     return row;
   }
 
-  async submitPayment(id: string): Promise<ReservationRow> {
+  async submit(id: string): Promise<ReservationRow> {
     const row = await this.db
       .updateTable("reservations")
-      .set({ status: "pending", updated_at: new Date() })
+      .set({ status: "submitted", updated_at: new Date() })
       .where("id", "=", id)
-      .where("status", "=", "on_hold")
+      .where("status", "=", "held")
       .returningAll()
       .executeTakeFirst();
 
     if (!row) {
-      throw new NotFoundException(`Reservation ${id} not found or not on_hold`);
+      throw new NotFoundException(`Reservation ${id} not found or not held`);
     }
 
     return row;
@@ -84,7 +85,7 @@ export class ReservationsRepository {
       .updateTable("reservations")
       .set({ status: "confirmed", updated_at: new Date() })
       .where("id", "=", id)
-      .where("status", "=", "pending")
+      .where("status", "=", "submitted")
       .returningAll()
       .executeTakeFirst();
 
@@ -95,16 +96,69 @@ export class ReservationsRepository {
     return row;
   }
 
+  async fail(id: string, reason: string): Promise<ReservationRow> {
+    const row = await this.db
+      .updateTable("reservations")
+      .set({ status: "failed", reason, updated_at: new Date() })
+      .where("id", "=", id)
+      .where("status", "=", "submitted")
+      .returningAll()
+      .executeTakeFirst();
+
+    if (!row) {
+      throw new NotFoundException(
+        `Reservation ${id} not found or not submitted`,
+      );
+    }
+
+    return row;
+  }
+
+  async cancel(
+    id: string,
+    reason: string,
+  ): Promise<{ row: ReservationRow; priorStatus: string }> {
+    return this.db.transaction().execute(async (trx) => {
+      // Lock the row so concurrent state transitions (e.g. payment webhook)
+      // cannot change status between our read and our update.
+      const current = await trx
+        .selectFrom("reservations")
+        .where("id", "=", id)
+        .select("status")
+        .forUpdate()
+        .executeTakeFirst();
+
+      if (!current) {
+        throw new NotFoundException(`Reservation ${id} not found`);
+      }
+
+      if (current.status === "expired" || current.status === "cancelled") {
+        throw new NotFoundException(
+          `Reservation ${id} is already terminal (${current.status})`,
+        );
+      }
+
+      const row = await trx
+        .updateTable("reservations")
+        .set({ status: "cancelled", reason, updated_at: new Date() })
+        .where("id", "=", id)
+        .returningAll()
+        .executeTakeFirstOrThrow();
+
+      return { row, priorStatus: current.status };
+    });
+  }
+
   async findExpiredHolds(): Promise<ReservationRow[]> {
     return this.db
       .selectFrom("reservations")
-      .where("status", "=", "on_hold")
+      .where("status", "=", "held")
       .where("hold_expires_at", "<", new Date())
       .selectAll()
       .execute();
   }
 
-  async findPendingByBookerAndStay(
+  async findHoldByBookerAndStay(
     bookerId: string,
     roomId: string,
     checkIn: string,
@@ -116,7 +170,7 @@ export class ReservationsRepository {
       .where("room_id", "=", roomId)
       .where("check_in", "=", checkIn)
       .where("check_out", "=", checkOut)
-      .where("status", "=", "on_hold")
+      .where("status", "=", "held")
       .selectAll()
       .executeTakeFirst();
 
@@ -146,7 +200,7 @@ export class ReservationsRepository {
       .updateTable("reservations")
       .set({ status: "expired", updated_at: new Date() })
       .where("id", "=", id)
-      .where("status", "=", "on_hold")
+      .where("status", "=", "held")
       .returningAll()
       .executeTakeFirst();
   }
@@ -161,6 +215,7 @@ export class ReservationsRepository {
       checkIn: row.check_in,
       checkOut: row.check_out,
       status: row.status,
+      reason: row.reason ?? null,
       fareBreakdown: row.fare_breakdown,
       taxTotalUsd: row.tax_total_usd ? parseFloat(row.tax_total_usd) : null,
       feeTotalUsd: row.fee_total_usd ? parseFloat(row.fee_total_usd) : null,

--- a/services/booking-service/src/reservations/reservations.repository.ts
+++ b/services/booking-service/src/reservations/reservations.repository.ts
@@ -195,6 +195,26 @@ export class ReservationsRepository {
     return row;
   }
 
+  async rehold(id: string, holdExpiresAt: Date): Promise<ReservationRow> {
+    const row = await this.db
+      .updateTable("reservations")
+      .set({
+        status: "held",
+        hold_expires_at: holdExpiresAt,
+        updated_at: new Date(),
+      })
+      .where("id", "=", id)
+      .where("status", "=", "failed")
+      .returningAll()
+      .executeTakeFirst();
+
+    if (!row) {
+      throw new NotFoundException(`Reservation ${id} not found or not failed`);
+    }
+
+    return row;
+  }
+
   async expire(id: string): Promise<ReservationRow | undefined> {
     return this.db
       .updateTable("reservations")

--- a/services/booking-service/src/reservations/reservations.service.spec.ts
+++ b/services/booking-service/src/reservations/reservations.service.spec.ts
@@ -31,7 +31,7 @@ function makeRow(overrides: Record<string, unknown> = {}) {
     },
     check_in: "2026-05-01",
     check_out: "2026-05-04",
-    status: "on_hold",
+    status: "held",
     fare_breakdown: null,
     tax_total_usd: "72.00",
     fee_total_usd: "0.00",
@@ -72,15 +72,19 @@ describe("ReservationsService", () => {
     findAll: jest.Mock;
     findByBookerId: jest.Mock;
     findById: jest.Mock;
-    findPendingByBookerAndStay: jest.Mock;
+    findHoldByBookerAndStay: jest.Mock;
     updateGuestInfo: jest.Mock;
     toResponse: jest.Mock;
     confirm: jest.Mock;
-    submitPayment: jest.Mock;
+    submit: jest.Mock;
+    fail: jest.Mock;
+    cancel: jest.Mock;
   };
   let inventoryClient: {
     getRoomLocation: jest.Mock;
     confirmHold: jest.Mock;
+    unhold: jest.Mock;
+    release: jest.Mock;
   };
   let holdsService: {
     create: jest.Mock;
@@ -95,6 +99,8 @@ describe("ReservationsService", () => {
     inventoryClient = {
       getRoomLocation: jest.fn().mockResolvedValue(LOCATION),
       confirmHold: jest.fn().mockResolvedValue(undefined),
+      unhold: jest.fn().mockResolvedValue(undefined),
+      release: jest.fn().mockResolvedValue(undefined),
     };
     holdsService = {
       create: jest
@@ -107,11 +113,13 @@ describe("ReservationsService", () => {
       findAll: jest.fn().mockResolvedValue([row, row]),
       findByBookerId: jest.fn().mockResolvedValue([row]),
       findById: jest.fn().mockResolvedValue(row),
-      findPendingByBookerAndStay: jest.fn().mockResolvedValue(null),
+      findHoldByBookerAndStay: jest.fn().mockResolvedValue(null),
       updateGuestInfo: jest.fn().mockResolvedValue(row),
       toResponse: jest.fn().mockImplementation((r) => ({ id: r.id })),
       confirm: jest.fn(),
-      submitPayment: jest.fn().mockResolvedValue(row),
+      submit: jest.fn().mockResolvedValue(row),
+      fail: jest.fn(),
+      cancel: jest.fn(),
     };
     service = new ReservationsService(
       fareCalculator as any,
@@ -179,7 +187,7 @@ describe("ReservationsService", () => {
           booker_id: "booker-uuid",
           check_in: "2026-05-01",
           check_out: "2026-05-04",
-          status: "on_hold",
+          status: "held",
           tax_total_usd: fareBreakdown.taxTotalUsd,
           fee_total_usd: fareBreakdown.feeTotalUsd,
           grand_total_usd: fareBreakdown.totalUsd,
@@ -217,11 +225,9 @@ describe("ReservationsService", () => {
       });
     });
 
-    it("returns existing pending reservation without creating a new hold (idempotency)", async () => {
+    it("returns existing held reservation without creating a new hold (idempotency)", async () => {
       const existingRow = makeRow({ fare_breakdown: fareBreakdown });
-      reservationsRepo.findPendingByBookerAndStay.mockResolvedValue(
-        existingRow,
-      );
+      reservationsRepo.findHoldByBookerAndStay.mockResolvedValue(existingRow);
 
       const result = await service.create(CREATE_DTO);
 
@@ -353,18 +359,172 @@ describe("ReservationsService", () => {
     });
   });
 
-  // ─── submitPayment ──────────────────────────────────────────────────────────
+  // ─── submit ─────────────────────────────────────────────────────────────────
 
-  describe("submitPayment", () => {
+  describe("submit", () => {
     it("delegates to repository and returns mapped response", async () => {
-      const pendingRow = makeRow({ status: "pending" });
-      reservationsRepo.submitPayment = jest.fn().mockResolvedValue(pendingRow);
+      const submittedRow = makeRow({ status: "submitted" });
+      reservationsRepo.submit = jest.fn().mockResolvedValue(submittedRow);
 
-      const result = await service.submitPayment("res-uuid");
+      const result = await service.submit("res-uuid");
 
-      expect(reservationsRepo.submitPayment).toHaveBeenCalledWith("res-uuid");
-      expect(reservationsRepo.toResponse).toHaveBeenCalledWith(pendingRow);
-      expect(result).toEqual({ id: pendingRow.id });
+      expect(reservationsRepo.submit).toHaveBeenCalledWith("res-uuid");
+      expect(reservationsRepo.toResponse).toHaveBeenCalledWith(submittedRow);
+      expect(result).toEqual({ id: submittedRow.id });
+    });
+  });
+
+  // ─── fail ───────────────────────────────────────────────────────────────────
+
+  describe("fail", () => {
+    it("delegates to repository with reason and returns mapped response", async () => {
+      const failedRow = makeRow({ status: "failed", reason: "card declined" });
+      reservationsRepo.fail = jest.fn().mockResolvedValue(failedRow);
+
+      await service.fail("res-uuid", "card declined");
+
+      expect(reservationsRepo.fail).toHaveBeenCalledWith(
+        "res-uuid",
+        "card declined",
+      );
+      expect(reservationsRepo.toResponse).toHaveBeenCalledWith(failedRow);
+    });
+
+    it("calls inventoryClient.unhold after marking as failed", async () => {
+      const failedRow = makeRow({ status: "failed" });
+      reservationsRepo.fail = jest.fn().mockResolvedValue(failedRow);
+
+      await service.fail("res-uuid", "card declined");
+
+      expect(inventoryClient.unhold).toHaveBeenCalledWith(
+        failedRow.room_id,
+        failedRow.check_in,
+        failedRow.check_out,
+      );
+    });
+
+    it("does not rethrow when inventoryClient.unhold fails", async () => {
+      reservationsRepo.fail = jest
+        .fn()
+        .mockResolvedValue(makeRow({ status: "failed" }));
+      inventoryClient.unhold.mockRejectedValue(new Error("inventory down"));
+
+      await expect(
+        service.fail("res-uuid", "card declined"),
+      ).resolves.not.toThrow();
+    });
+
+    it("propagates NotFoundException when reservation is not submitted", async () => {
+      reservationsRepo.fail = jest
+        .fn()
+        .mockRejectedValue(new NotFoundException("not submitted"));
+
+      await expect(service.fail("res-uuid", "card declined")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  // ─── cancel ─────────────────────────────────────────────────────────────────
+
+  describe("cancel", () => {
+    it("calls inventoryClient.unhold when cancelling a held reservation", async () => {
+      const cancelledRow = makeRow({
+        status: "cancelled",
+        reason: "changed mind",
+      });
+      reservationsRepo.cancel = jest
+        .fn()
+        .mockResolvedValue({ row: cancelledRow, priorStatus: "held" });
+
+      await service.cancel("res-uuid", "changed mind");
+
+      expect(inventoryClient.unhold).toHaveBeenCalledWith(
+        cancelledRow.room_id,
+        cancelledRow.check_in,
+        cancelledRow.check_out,
+      );
+      expect(inventoryClient.release).not.toHaveBeenCalled();
+    });
+
+    it("calls inventoryClient.unhold when cancelling a submitted reservation", async () => {
+      const cancelledRow = makeRow({ status: "cancelled" });
+      reservationsRepo.cancel = jest
+        .fn()
+        .mockResolvedValue({ row: cancelledRow, priorStatus: "submitted" });
+
+      await service.cancel("res-uuid", "changed mind");
+
+      expect(inventoryClient.unhold).toHaveBeenCalledWith(
+        cancelledRow.room_id,
+        cancelledRow.check_in,
+        cancelledRow.check_out,
+      );
+    });
+
+    it("calls inventoryClient.release when cancelling a confirmed reservation", async () => {
+      const cancelledRow = makeRow({ status: "cancelled" });
+      reservationsRepo.cancel = jest
+        .fn()
+        .mockResolvedValue({ row: cancelledRow, priorStatus: "confirmed" });
+
+      await service.cancel("res-uuid", "changed mind");
+
+      expect(inventoryClient.release).toHaveBeenCalledWith(
+        cancelledRow.room_id,
+        cancelledRow.check_in,
+        cancelledRow.check_out,
+      );
+      expect(inventoryClient.unhold).not.toHaveBeenCalled();
+    });
+
+    it("calls no inventory method when cancelling a failed reservation", async () => {
+      const cancelledRow = makeRow({ status: "cancelled" });
+      reservationsRepo.cancel = jest
+        .fn()
+        .mockResolvedValue({ row: cancelledRow, priorStatus: "failed" });
+
+      await service.cancel("res-uuid", "giving up");
+
+      expect(inventoryClient.unhold).not.toHaveBeenCalled();
+      expect(inventoryClient.release).not.toHaveBeenCalled();
+    });
+
+    it("does not rethrow when inventory call fails", async () => {
+      const cancelledRow = makeRow({ status: "cancelled" });
+      reservationsRepo.cancel = jest
+        .fn()
+        .mockResolvedValue({ row: cancelledRow, priorStatus: "confirmed" });
+      inventoryClient.release.mockRejectedValue(new Error("inventory down"));
+
+      await expect(
+        service.cancel("res-uuid", "changed mind"),
+      ).resolves.not.toThrow();
+    });
+
+    it("propagates NotFoundException when reservation is already terminal", async () => {
+      reservationsRepo.cancel = jest
+        .fn()
+        .mockRejectedValue(new NotFoundException("already terminal"));
+
+      await expect(service.cancel("res-uuid", "changed mind")).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it("returns mapped response", async () => {
+      const cancelledRow = makeRow({
+        status: "cancelled",
+        reason: "changed mind",
+      });
+      reservationsRepo.cancel = jest
+        .fn()
+        .mockResolvedValue({ row: cancelledRow, priorStatus: "held" });
+
+      const result = await service.cancel("res-uuid", "changed mind");
+
+      expect(reservationsRepo.toResponse).toHaveBeenCalledWith(cancelledRow);
+      expect(result).toEqual({ id: cancelledRow.id });
     });
   });
 

--- a/services/booking-service/src/reservations/reservations.service.spec.ts
+++ b/services/booking-service/src/reservations/reservations.service.spec.ts
@@ -79,6 +79,7 @@ describe("ReservationsService", () => {
     submit: jest.Mock;
     fail: jest.Mock;
     cancel: jest.Mock;
+    rehold: jest.Mock;
   };
   let inventoryClient: {
     getRoomLocation: jest.Mock;
@@ -120,6 +121,7 @@ describe("ReservationsService", () => {
       submit: jest.fn().mockResolvedValue(row),
       fail: jest.fn(),
       cancel: jest.fn(),
+      rehold: jest.fn().mockResolvedValue(row),
     };
     service = new ReservationsService(
       fareCalculator as any,
@@ -625,6 +627,64 @@ describe("ReservationsService", () => {
           taxTotalUsd: 72,
           feeTotalUsd: 0,
         }),
+      );
+    });
+  });
+
+  // ─── rehold ──────────────────────────────────────────────────────────────────
+
+  describe("rehold", () => {
+    it("calls findById, holdsService.create, and repo.rehold with the new expiry", async () => {
+      const failedRow = makeRow({ status: "failed" });
+      reservationsRepo.findById = jest.fn().mockResolvedValue(failedRow);
+
+      await service.rehold("res-uuid");
+
+      expect(reservationsRepo.findById).toHaveBeenCalledWith("res-uuid");
+      expect(holdsService.create).toHaveBeenCalledWith({
+        bookerId: failedRow.booker_id,
+        roomId: failedRow.room_id,
+        checkIn: failedRow.check_in,
+        checkOut: failedRow.check_out,
+      });
+      expect(reservationsRepo.rehold).toHaveBeenCalledWith(
+        "res-uuid",
+        expect.any(Date),
+      );
+    });
+
+    it("returns the mapped response", async () => {
+      const reheld = makeRow({ status: "held" });
+      reservationsRepo.rehold = jest.fn().mockResolvedValue(reheld);
+
+      const result = await service.rehold("res-uuid");
+
+      expect(reservationsRepo.toResponse).toHaveBeenCalledWith(reheld);
+      expect(result).toEqual({ id: reheld.id });
+    });
+
+    it("releases the new hold when repo.rehold fails", async () => {
+      reservationsRepo.rehold = jest
+        .fn()
+        .mockRejectedValue(new NotFoundException("not failed"));
+
+      await expect(service.rehold("res-uuid")).rejects.toThrow(
+        NotFoundException,
+      );
+
+      expect(holdsService.release).toHaveBeenCalledWith(HOLD_ID);
+    });
+
+    it("does not rethrow the hold-release error when release itself fails", async () => {
+      reservationsRepo.rehold = jest
+        .fn()
+        .mockRejectedValue(new NotFoundException("not failed"));
+      holdsService.release = jest
+        .fn()
+        .mockRejectedValue(new Error("redis down"));
+
+      await expect(service.rehold("res-uuid")).rejects.toThrow(
+        NotFoundException,
       );
     });
   });

--- a/services/booking-service/src/reservations/reservations.service.ts
+++ b/services/booking-service/src/reservations/reservations.service.ts
@@ -224,6 +224,30 @@ export class ReservationsService {
     return this.reservationsRepo.toResponse(row);
   }
 
+  async rehold(id: string) {
+    const row = await this.reservationsRepo.findById(id);
+
+    const { holdId, expiresAt } = await this.holdsService.create({
+      bookerId: row.booker_id,
+      roomId: row.room_id,
+      checkIn: row.check_in,
+      checkOut: row.check_out,
+    });
+
+    const updated = await this.reservationsRepo
+      .rehold(id, new Date(expiresAt))
+      .catch(async (err) => {
+        await this.holdsService.release(holdId).catch((releaseErr) => {
+          this.logger.warn(
+            `Failed to release hold ${holdId} after rehold error: ${releaseErr}`,
+          );
+        });
+        throw err;
+      });
+
+    return this.reservationsRepo.toResponse(updated);
+  }
+
   async confirm(id: string) {
     const row = await this.reservationsRepo.confirm(id);
 

--- a/services/booking-service/src/reservations/reservations.service.ts
+++ b/services/booking-service/src/reservations/reservations.service.ts
@@ -38,8 +38,8 @@ export class ReservationsService {
   }
 
   async create(dto: CreateReservationDto) {
-    // Idempotency guard — return existing pending reservation if one already exists
-    const existing = await this.reservationsRepo.findPendingByBookerAndStay(
+    // Idempotency guard — return existing held reservation if one already exists
+    const existing = await this.reservationsRepo.findHoldByBookerAndStay(
       dto.bookerId,
       dto.roomId,
       dto.checkIn,
@@ -102,7 +102,7 @@ export class ReservationsService {
         booker_id: dto.bookerId,
         check_in: dto.checkIn,
         check_out: dto.checkOut,
-        status: "on_hold",
+        status: "held",
         fare_breakdown: fareBreakdown,
         tax_total_usd: fareBreakdown.taxTotalUsd,
         fee_total_usd: fareBreakdown.feeTotalUsd,
@@ -114,7 +114,7 @@ export class ReservationsService {
       // Re-query and return the existing pending reservation idempotently.
       if (err?.code === "23505") {
         await this.holdsService.release(holdId).catch(() => undefined);
-        const existing = await this.reservationsRepo.findPendingByBookerAndStay(
+        const existing = await this.reservationsRepo.findHoldByBookerAndStay(
           dto.bookerId,
           dto.roomId,
           dto.checkIn,
@@ -174,8 +174,53 @@ export class ReservationsService {
     return this.reservationsRepo.toResponse(row);
   }
 
-  async submitPayment(id: string) {
-    const row = await this.reservationsRepo.submitPayment(id);
+  async submit(id: string) {
+    const row = await this.reservationsRepo.submit(id);
+    return this.reservationsRepo.toResponse(row);
+  }
+
+  async fail(id: string, reason: string) {
+    const row = await this.reservationsRepo.fail(id, reason);
+
+    try {
+      await this.inventoryClient.unhold(
+        row.room_id,
+        row.check_in,
+        row.check_out,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to unhold inventory for failed reservation ${id}: ${err}`,
+      );
+    }
+
+    return this.reservationsRepo.toResponse(row);
+  }
+
+  async cancel(id: string, reason: string) {
+    const { row, priorStatus } = await this.reservationsRepo.cancel(id, reason);
+
+    try {
+      if (priorStatus === "confirmed") {
+        await this.inventoryClient.release(
+          row.room_id,
+          row.check_in,
+          row.check_out,
+        );
+      } else if (priorStatus === "held" || priorStatus === "submitted") {
+        await this.inventoryClient.unhold(
+          row.room_id,
+          row.check_in,
+          row.check_out,
+        );
+      }
+      // failed: already unheld by fail() — no-op
+    } catch (err) {
+      this.logger.warn(
+        `Failed to update inventory for cancelled reservation ${id}: ${err}`,
+      );
+    }
+
     return this.reservationsRepo.toResponse(row);
   }
 

--- a/services/notification-service/src/app.controller.ts
+++ b/services/notification-service/src/app.controller.ts
@@ -24,6 +24,7 @@ export class AppController {
       channel: string;
       subject: string;
       message: string;
+      html?: string;
     },
   ) {
     return this.appService.sendNotification(body);

--- a/services/notification-service/src/app.service.spec.ts
+++ b/services/notification-service/src/app.service.spec.ts
@@ -145,6 +145,7 @@ describe("AppService", () => {
         "user@example.com",
         "Welcome",
         "Thanks for booking",
+        undefined,
       );
     });
 

--- a/services/notification-service/src/app.service.ts
+++ b/services/notification-service/src/app.service.ts
@@ -37,11 +37,14 @@ export class AppService {
     channel: string;
     subject: string;
     message: string;
+    html?: string;
   }): object {
     if (body.channel === "email" && body.to) {
-      this.sendEmail(body.to, body.subject, body.message).catch((err) => {
-        console.error("[notification-service] Email send error:", err);
-      });
+      this.sendEmail(body.to, body.subject, body.message, body.html).catch(
+        (err) => {
+          console.error("[notification-service] Email send error:", err);
+        },
+      );
     }
 
     return {
@@ -56,6 +59,7 @@ export class AppService {
     to: string,
     subject: string,
     text: string,
+    html?: string,
   ): Promise<void> {
     const smtpHost = process.env.SMTP_HOST;
 
@@ -81,6 +85,7 @@ export class AppService {
       to,
       subject,
       text,
+      ...(html ? { html } : {}),
     });
   }
 }

--- a/services/payment-service/src/clients/booking.client.spec.ts
+++ b/services/payment-service/src/clients/booking.client.spec.ts
@@ -1,0 +1,145 @@
+import { BookingClient } from "./booking.client.js";
+import { UpstreamServiceError } from "./upstream-service.error.js";
+
+// ─── fetch mock ───────────────────────────────────────────────────────────────
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function okResponse() {
+  return Promise.resolve({ ok: true, status: 200 } as Response);
+}
+
+function errorResponse(status = 500) {
+  return Promise.resolve({ ok: false, status } as Response);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("BookingClient", () => {
+  let client: BookingClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new BookingClient();
+  });
+
+  // ─── submitReservation ─────────────────────────────────────────────────────
+
+  describe("submitReservation", () => {
+    it("sends PATCH to /reservations/:id/submit", async () => {
+      mockFetch.mockReturnValue(okResponse());
+
+      await client.submitReservation("res-uuid");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/reservations/res-uuid/submit"),
+        expect.objectContaining({ method: "PATCH" }),
+      );
+    });
+
+    it("throws UpstreamServiceError when the response is not ok", async () => {
+      mockFetch.mockReturnValue(errorResponse(404));
+
+      await expect(client.submitReservation("res-uuid")).rejects.toThrow(
+        UpstreamServiceError,
+      );
+    });
+
+    it("wraps network errors in UpstreamServiceError", async () => {
+      mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const err = await client.submitReservation("res-uuid").catch((e) => e);
+
+      expect(err).toBeInstanceOf(UpstreamServiceError);
+      expect(err.service).toBe("booking-service");
+    });
+
+    it("does not double-wrap UpstreamServiceError", async () => {
+      mockFetch.mockRejectedValue(
+        new UpstreamServiceError("booking-service", "already wrapped"),
+      );
+
+      const err = await client.submitReservation("res-uuid").catch((e) => e);
+
+      expect(err).toBeInstanceOf(UpstreamServiceError);
+      // cause is the string, not another UpstreamServiceError
+      expect(err.cause).toBe("already wrapped");
+    });
+  });
+
+  // ─── reholdReservation ─────────────────────────────────────────────────────
+
+  describe("reholdReservation", () => {
+    it("sends PATCH to /reservations/:id/rehold", async () => {
+      mockFetch.mockReturnValue(okResponse());
+
+      await client.reholdReservation("res-uuid");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/reservations/res-uuid/rehold"),
+        expect.objectContaining({ method: "PATCH" }),
+      );
+    });
+
+    it("throws UpstreamServiceError when the response is not ok", async () => {
+      mockFetch.mockReturnValue(errorResponse(409));
+
+      await expect(client.reholdReservation("res-uuid")).rejects.toThrow(
+        UpstreamServiceError,
+      );
+    });
+  });
+
+  // ─── confirmReservation ────────────────────────────────────────────────────
+
+  describe("confirmReservation", () => {
+    it("sends PATCH to /reservations/:id/confirm", async () => {
+      mockFetch.mockReturnValue(okResponse());
+
+      await client.confirmReservation("res-uuid");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/reservations/res-uuid/confirm"),
+        expect.objectContaining({ method: "PATCH" }),
+      );
+    });
+
+    it("throws UpstreamServiceError when the response is not ok", async () => {
+      mockFetch.mockReturnValue(errorResponse(500));
+
+      await expect(client.confirmReservation("res-uuid")).rejects.toThrow(
+        UpstreamServiceError,
+      );
+    });
+  });
+
+  // ─── failReservation ───────────────────────────────────────────────────────
+
+  describe("failReservation", () => {
+    it("sends PATCH to /reservations/:id/fail with JSON body", async () => {
+      mockFetch.mockReturnValue(okResponse());
+
+      await client.failReservation("res-uuid", "Your card was declined.");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/reservations/res-uuid/fail"),
+        expect.objectContaining({
+          method: "PATCH",
+          headers: expect.objectContaining({
+            "content-type": "application/json",
+          }),
+          body: JSON.stringify({ reason: "Your card was declined." }),
+        }),
+      );
+    });
+
+    it("throws UpstreamServiceError when the response is not ok", async () => {
+      mockFetch.mockReturnValue(errorResponse(422));
+
+      await expect(
+        client.failReservation("res-uuid", "Insufficient funds."),
+      ).rejects.toThrow(UpstreamServiceError);
+    });
+  });
+});

--- a/services/payment-service/src/clients/booking.client.ts
+++ b/services/payment-service/src/clients/booking.client.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { UpstreamServiceError } from "./upstream-service.error.js";
+
+@Injectable()
+export class BookingClient {
+  private readonly logger = new Logger(BookingClient.name);
+  private readonly baseUrl =
+    process.env.BOOKING_SERVICE_URL ?? "http://localhost:3004";
+
+  async confirmReservation(reservationId: string): Promise<void> {
+    try {
+      const res = await fetch(
+        `${this.baseUrl}/reservations/${reservationId}/confirm`,
+        { method: "PATCH" },
+      );
+      if (!res.ok) {
+        throw new UpstreamServiceError("booking-service", `HTTP ${res.status}`);
+      }
+      this.logger.log(`Booking confirmed: ${reservationId}`);
+    } catch (err) {
+      if (err instanceof UpstreamServiceError) throw err;
+      throw new UpstreamServiceError("booking-service", err);
+    }
+  }
+
+  async failReservation(reservationId: string, reason: string): Promise<void> {
+    try {
+      const res = await fetch(
+        `${this.baseUrl}/reservations/${reservationId}/fail`,
+        {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ reason }),
+        },
+      );
+      if (!res.ok) {
+        throw new UpstreamServiceError("booking-service", `HTTP ${res.status}`);
+      }
+      this.logger.log(`Booking marked failed: ${reservationId}`);
+    } catch (err) {
+      if (err instanceof UpstreamServiceError) throw err;
+      throw new UpstreamServiceError("booking-service", err);
+    }
+  }
+}

--- a/services/payment-service/src/clients/booking.client.ts
+++ b/services/payment-service/src/clients/booking.client.ts
@@ -7,6 +7,38 @@ export class BookingClient {
   private readonly baseUrl =
     process.env.BOOKING_SERVICE_URL ?? "http://localhost:3004";
 
+  async submitReservation(reservationId: string): Promise<void> {
+    try {
+      const res = await fetch(
+        `${this.baseUrl}/reservations/${reservationId}/submit`,
+        { method: "PATCH" },
+      );
+      if (!res.ok) {
+        throw new UpstreamServiceError("booking-service", `HTTP ${res.status}`);
+      }
+      this.logger.log(`Booking submitted: ${reservationId}`);
+    } catch (err) {
+      if (err instanceof UpstreamServiceError) throw err;
+      throw new UpstreamServiceError("booking-service", err);
+    }
+  }
+
+  async reholdReservation(reservationId: string): Promise<void> {
+    try {
+      const res = await fetch(
+        `${this.baseUrl}/reservations/${reservationId}/rehold`,
+        { method: "PATCH" },
+      );
+      if (!res.ok) {
+        throw new UpstreamServiceError("booking-service", `HTTP ${res.status}`);
+      }
+      this.logger.log(`Booking rehold: ${reservationId}`);
+    } catch (err) {
+      if (err instanceof UpstreamServiceError) throw err;
+      throw new UpstreamServiceError("booking-service", err);
+    }
+  }
+
   async confirmReservation(reservationId: string): Promise<void> {
     try {
       const res = await fetch(

--- a/services/payment-service/src/clients/clients.module.ts
+++ b/services/payment-service/src/clients/clients.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { BookingClient } from "./booking.client.js";
+import { NotificationClient } from "./notification.client.js";
+
+@Module({
+  providers: [BookingClient, NotificationClient],
+  exports: [BookingClient, NotificationClient],
+})
+export class ClientsModule {}

--- a/services/payment-service/src/clients/notification.client.spec.ts
+++ b/services/payment-service/src/clients/notification.client.spec.ts
@@ -1,0 +1,115 @@
+import { NotificationClient } from "./notification.client.js";
+
+// ─── fetch mock ───────────────────────────────────────────────────────────────
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function okResponse() {
+  return Promise.resolve({ ok: true, status: 200 } as Response);
+}
+
+function errorResponse(status = 500) {
+  return Promise.resolve({ ok: false, status } as Response);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("NotificationClient", () => {
+  let client: NotificationClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new NotificationClient();
+  });
+
+  // ─── sendPaymentSucceeded ──────────────────────────────────────────────────
+
+  describe("sendPaymentSucceeded", () => {
+    it("posts to /notifications/send with correct fields", async () => {
+      mockFetch.mockReturnValue(okResponse());
+
+      await client.sendPaymentSucceeded({
+        to: "guest@example.com",
+        reservationId: "res-uuid",
+        amountUsd: 350.5,
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining("/notifications/send"),
+        expect.objectContaining({
+          method: "POST",
+          headers: expect.objectContaining({
+            "content-type": "application/json",
+          }),
+        }),
+      );
+
+      const body = JSON.parse(
+        (mockFetch.mock.calls[0][1] as RequestInit).body as string,
+      );
+      expect(body.to).toBe("guest@example.com");
+      expect(body.userId).toBe("res-uuid");
+      expect(body.channel).toBe("email");
+      expect(body.message).toContain("350.50");
+    });
+
+    it("does not throw when notification-service returns non-200", async () => {
+      mockFetch.mockReturnValue(errorResponse(503));
+
+      await expect(
+        client.sendPaymentSucceeded({
+          to: "guest@example.com",
+          reservationId: "res-uuid",
+          amountUsd: 100,
+        }),
+      ).resolves.not.toThrow();
+    });
+
+    it("does not throw when fetch rejects (network error)", async () => {
+      mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      await expect(
+        client.sendPaymentSucceeded({
+          to: "guest@example.com",
+          reservationId: "res-uuid",
+          amountUsd: 100,
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  // ─── sendPaymentFailed ─────────────────────────────────────────────────────
+
+  describe("sendPaymentFailed", () => {
+    it("posts to /notifications/send with reason in body", async () => {
+      mockFetch.mockReturnValue(okResponse());
+
+      await client.sendPaymentFailed({
+        to: "guest@example.com",
+        reservationId: "res-uuid",
+        reason: "Insufficient funds.",
+      });
+
+      const body = JSON.parse(
+        (mockFetch.mock.calls[0][1] as RequestInit).body as string,
+      );
+      expect(body.to).toBe("guest@example.com");
+      expect(body.userId).toBe("res-uuid");
+      expect(body.channel).toBe("email");
+      expect(body.message).toContain("Insufficient funds.");
+    });
+
+    it("does not throw when notification-service is unavailable", async () => {
+      mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      await expect(
+        client.sendPaymentFailed({
+          to: "guest@example.com",
+          reservationId: "res-uuid",
+          reason: "Card declined.",
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
+});

--- a/services/payment-service/src/clients/notification.client.ts
+++ b/services/payment-service/src/clients/notification.client.ts
@@ -1,16 +1,16 @@
 import { Injectable, Logger } from "@nestjs/common";
-import * as nodemailer from "nodemailer";
 
 @Injectable()
-export class EmailService {
-  private readonly logger = new Logger(EmailService.name);
+export class NotificationClient {
+  private readonly logger = new Logger(NotificationClient.name);
+  private readonly baseUrl =
+    process.env.NOTIFICATION_SERVICE_URL ?? "http://localhost:3006";
 
   async sendPaymentSucceeded(opts: {
     to: string;
     reservationId: string;
     amountUsd: string | number;
   }): Promise<void> {
-    const subject = "Reserva confirmada — TravelHub";
     const html = `
       <div style="font-family:sans-serif;max-width:520px;margin:auto;padding:32px">
         <h2 style="color:#1a56db">¡Tu reserva está confirmada!</h2>
@@ -31,7 +31,14 @@ export class EmailService {
         <p style="color:#6b7280;font-size:13px">— El equipo de TravelHub</p>
       </div>
     `;
-    await this.send(opts.to, subject, html);
+    await this.send({
+      userId: opts.reservationId,
+      to: opts.to,
+      channel: "email",
+      subject: "Reserva confirmada — TravelHub",
+      message: `Tu reserva ${opts.reservationId} ha sido confirmada. Total: USD $${Number(opts.amountUsd).toFixed(2)}`,
+      html,
+    });
   }
 
   async sendPaymentFailed(opts: {
@@ -39,7 +46,6 @@ export class EmailService {
     reservationId: string;
     reason: string;
   }): Promise<void> {
-    const subject = "Pago no procesado — TravelHub";
     const html = `
       <div style="font-family:sans-serif;max-width:520px;margin:auto;padding:32px">
         <h2 style="color:#dc2626">No pudimos procesar tu pago</h2>
@@ -60,36 +66,30 @@ export class EmailService {
         <p style="color:#6b7280;font-size:13px">— El equipo de TravelHub</p>
       </div>
     `;
-    await this.send(opts.to, subject, html);
-  }
-
-  private async send(to: string, subject: string, html: string): Promise<void> {
-    const smtpHost = process.env.SMTP_HOST;
-
-    if (!smtpHost) {
-      this.logger.log(
-        `[DEV MODE] Email to <${to}> | Subject: ${subject} | (SMTP not configured)`,
-      );
-      return;
-    }
-
-    const transporter = nodemailer.createTransport({
-      host: smtpHost,
-      port: parseInt(process.env.SMTP_PORT ?? "587"),
-      secure: process.env.SMTP_SECURE === "true",
-      auth: {
-        user: process.env.SMTP_USER,
-        pass: process.env.SMTP_PASS,
-      },
-    });
-
-    await transporter.sendMail({
-      from: process.env.SMTP_FROM ?? "noreply@travelhub.com",
-      to,
-      subject,
+    await this.send({
+      userId: opts.reservationId,
+      to: opts.to,
+      channel: "email",
+      subject: "Pago no procesado — TravelHub",
+      message: `No pudimos procesar el pago para la reserva ${opts.reservationId}. Motivo: ${opts.reason}`,
       html,
     });
+  }
 
-    this.logger.log(`Email sent to <${to}> | Subject: ${subject}`);
+  private async send(payload: object): Promise<void> {
+    try {
+      const res = await fetch(`${this.baseUrl}/notifications/send`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        this.logger.error(
+          `notification-service responded ${res.status} for payload ${JSON.stringify(payload)}`,
+        );
+      }
+    } catch (err) {
+      this.logger.error(`Failed to reach notification-service: ${err}`);
+    }
   }
 }

--- a/services/payment-service/src/clients/upstream-service.error.spec.ts
+++ b/services/payment-service/src/clients/upstream-service.error.spec.ts
@@ -1,0 +1,34 @@
+import { UpstreamServiceError } from "./upstream-service.error.js";
+
+describe("UpstreamServiceError", () => {
+  it("is an instance of Error", () => {
+    const err = new UpstreamServiceError("booking-service");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("sets name to UpstreamServiceError", () => {
+    const err = new UpstreamServiceError("booking-service");
+    expect(err.name).toBe("UpstreamServiceError");
+  });
+
+  it("sets message to include the service name", () => {
+    const err = new UpstreamServiceError("booking-service");
+    expect(err.message).toContain("booking-service");
+  });
+
+  it("exposes the service property", () => {
+    const err = new UpstreamServiceError("payment-service");
+    expect(err.service).toBe("payment-service");
+  });
+
+  it("stores cause when provided", () => {
+    const cause = new Error("network timeout");
+    const err = new UpstreamServiceError("booking-service", cause);
+    expect(err.cause).toBe(cause);
+  });
+
+  it("cause is undefined when not provided", () => {
+    const err = new UpstreamServiceError("booking-service");
+    expect(err.cause).toBeUndefined();
+  });
+});

--- a/services/payment-service/src/clients/upstream-service.error.ts
+++ b/services/payment-service/src/clients/upstream-service.error.ts
@@ -1,0 +1,9 @@
+export class UpstreamServiceError extends Error {
+  constructor(
+    public readonly service: string,
+    public readonly cause?: unknown,
+  ) {
+    super(`Upstream service error: ${service}`);
+    this.name = "UpstreamServiceError";
+  }
+}

--- a/services/payment-service/src/database/migrations/20260424_002_drop_reservation_unique.ts
+++ b/services/payment-service/src/database/migrations/20260424_002_drop_reservation_unique.ts
@@ -1,0 +1,17 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+// Allow multiple payment attempts per reservation (e.g. retry after card decline).
+// The unique index on stripe_payment_intent_id remains — each attempt still maps
+// to exactly one Stripe intent.
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE payments DROP CONSTRAINT IF EXISTS payments_reservation_id_key
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE payments ADD CONSTRAINT payments_reservation_id_key UNIQUE (reservation_id)
+  `.execute(db);
+}

--- a/services/payment-service/src/payments/payments.module.ts
+++ b/services/payment-service/src/payments/payments.module.ts
@@ -2,10 +2,11 @@ import { Module } from "@nestjs/common";
 import { PaymentsController } from "./payments.controller.js";
 import { PaymentsService } from "./payments.service.js";
 import { PaymentsRepository } from "./payments.repository.js";
-import { EmailService } from "./email.service.js";
+import { ClientsModule } from "../clients/clients.module.js";
 
 @Module({
+  imports: [ClientsModule],
   controllers: [PaymentsController],
-  providers: [PaymentsService, PaymentsRepository, EmailService],
+  providers: [PaymentsService, PaymentsRepository],
 })
 export class PaymentsModule {}

--- a/services/payment-service/src/payments/payments.repository.spec.ts
+++ b/services/payment-service/src/payments/payments.repository.spec.ts
@@ -16,6 +16,7 @@ function makeDb(
     "set",
     "where",
     "selectAll",
+    "orderBy",
     "values",
     "returningAll",
   ];

--- a/services/payment-service/src/payments/payments.repository.ts
+++ b/services/payment-service/src/payments/payments.repository.ts
@@ -27,6 +27,7 @@ export class PaymentsRepository {
       .selectFrom("payments")
       .selectAll()
       .where("reservation_id", "=", reservationId)
+      .orderBy("created_at", "desc")
       .executeTakeFirst();
   }
 

--- a/services/payment-service/src/payments/payments.service.spec.ts
+++ b/services/payment-service/src/payments/payments.service.spec.ts
@@ -31,7 +31,14 @@ function makeRepo() {
   };
 }
 
-function makeEmail() {
+function makeBookingClient() {
+  return {
+    confirmReservation: jest.fn().mockResolvedValue(undefined),
+    failReservation: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeNotifications() {
   return {
     sendPaymentSucceeded: jest.fn().mockResolvedValue(undefined),
     sendPaymentFailed: jest.fn().mockResolvedValue(undefined),
@@ -82,13 +89,19 @@ const INITIATE_DTO = {
 describe("PaymentsService", () => {
   let service: PaymentsService;
   let repo: ReturnType<typeof makeRepo>;
-  let email: ReturnType<typeof makeEmail>;
+  let booking: ReturnType<typeof makeBookingClient>;
+  let notifications: ReturnType<typeof makeNotifications>;
 
   beforeEach(() => {
     jest.clearAllMocks();
     repo = makeRepo();
-    email = makeEmail();
-    service = new PaymentsService(repo as any, email as any);
+    booking = makeBookingClient();
+    notifications = makeNotifications();
+    service = new PaymentsService(
+      repo as any,
+      booking as any,
+      notifications as any,
+    );
   });
 
   // ─── initiate ─────────────────────────────────────────────────────────────
@@ -180,7 +193,6 @@ describe("PaymentsService", () => {
           type: "payment_intent.succeeded",
           data: { object: intent },
         });
-        mockFetch.mockResolvedValue({ ok: true });
 
         await service.handleWebhook(rawBody, sig);
 
@@ -198,7 +210,6 @@ describe("PaymentsService", () => {
           type: "payment_intent.succeeded",
           data: { object: intent },
         });
-        mockFetch.mockResolvedValue({ ok: true });
 
         await service.handleWebhook(rawBody, sig);
 
@@ -210,19 +221,15 @@ describe("PaymentsService", () => {
         );
       });
 
-      it("calls booking-service PATCH /reservations/{id}/confirm", async () => {
+      it("calls BookingClient.confirmReservation with the reservation id", async () => {
         mockWebhooksConstructEvent.mockReturnValue({
           type: "payment_intent.succeeded",
           data: { object: makeStripeIntent() },
         });
-        mockFetch.mockResolvedValue({ ok: true });
 
         await service.handleWebhook(rawBody, sig);
 
-        expect(mockFetch).toHaveBeenCalledWith(
-          expect.stringContaining("/reservations/res-uuid/confirm"),
-          expect.objectContaining({ method: "PATCH" }),
-        );
+        expect(booking.confirmReservation).toHaveBeenCalledWith("res-uuid");
       });
 
       it("sends the payment-succeeded email to the guest", async () => {
@@ -230,11 +237,10 @@ describe("PaymentsService", () => {
           type: "payment_intent.succeeded",
           data: { object: makeStripeIntent() },
         });
-        mockFetch.mockResolvedValue({ ok: true });
 
         await service.handleWebhook(rawBody, sig);
 
-        expect(email.sendPaymentSucceeded).toHaveBeenCalledWith(
+        expect(notifications.sendPaymentSucceeded).toHaveBeenCalledWith(
           expect.objectContaining({
             to: "guest@example.com",
             reservationId: "res-uuid",
@@ -248,7 +254,7 @@ describe("PaymentsService", () => {
           type: "payment_intent.succeeded",
           data: { object: makeStripeIntent() },
         });
-        mockFetch.mockResolvedValue({ ok: false, status: 503 });
+        booking.confirmReservation.mockRejectedValue(new Error("unavailable"));
 
         await expect(
           service.handleWebhook(rawBody, sig),
@@ -300,7 +306,7 @@ describe("PaymentsService", () => {
 
         await service.handleWebhook(rawBody, sig);
 
-        expect(email.sendPaymentFailed).toHaveBeenCalledWith(
+        expect(notifications.sendPaymentFailed).toHaveBeenCalledWith(
           expect.objectContaining({
             to: "guest@example.com",
             reservationId: "res-uuid",
@@ -309,7 +315,38 @@ describe("PaymentsService", () => {
         );
       });
 
-      it("does not call booking-service confirm for failed payments", async () => {
+      it("calls BookingClient.failReservation with reservation id and Stripe reason", async () => {
+        const intent = makeStripeIntent({
+          last_payment_error: { message: "Your card was declined." },
+        });
+        mockWebhooksConstructEvent.mockReturnValue({
+          type: "payment_intent.payment_failed",
+          data: { object: intent },
+        });
+
+        await service.handleWebhook(rawBody, sig);
+
+        expect(booking.failReservation).toHaveBeenCalledWith(
+          "res-uuid",
+          "Your card was declined.",
+        );
+      });
+
+      it("passes 'Payment declined' fallback reason when last_payment_error is null", async () => {
+        mockWebhooksConstructEvent.mockReturnValue({
+          type: "payment_intent.payment_failed",
+          data: { object: makeStripeIntent({ last_payment_error: null }) },
+        });
+
+        await service.handleWebhook(rawBody, sig);
+
+        expect(booking.failReservation).toHaveBeenCalledWith(
+          "res-uuid",
+          "Payment declined",
+        );
+      });
+
+      it("does not call BookingClient.confirmReservation for failed payments", async () => {
         mockWebhooksConstructEvent.mockReturnValue({
           type: "payment_intent.payment_failed",
           data: { object: makeStripeIntent() },
@@ -317,7 +354,7 @@ describe("PaymentsService", () => {
 
         await service.handleWebhook(rawBody, sig);
 
-        expect(mockFetch).not.toHaveBeenCalled();
+        expect(booking.confirmReservation).not.toHaveBeenCalled();
       });
     });
 

--- a/services/payment-service/src/payments/payments.service.spec.ts
+++ b/services/payment-service/src/payments/payments.service.spec.ts
@@ -33,6 +33,8 @@ function makeRepo() {
 
 function makeBookingClient() {
   return {
+    submitReservation: jest.fn().mockResolvedValue(undefined),
+    reholdReservation: jest.fn().mockResolvedValue(undefined),
     confirmReservation: jest.fn().mockResolvedValue(undefined),
     failReservation: jest.fn().mockResolvedValue(undefined),
   };

--- a/services/payment-service/src/payments/payments.service.spec.ts
+++ b/services/payment-service/src/payments/payments.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { PaymentsService } from "./payments.service.js";
+import { UpstreamServiceError } from "../clients/upstream-service.error.js";
 
 // ─── Stripe mock ──────────────────────────────────────────────────────────────
 // Jest hoists this before the import of payments.service, so the module-level
@@ -170,6 +171,31 @@ describe("PaymentsService", () => {
         clientSecret: "pi_test_abc_secret",
       });
     });
+
+    it("calls submitReservation on first attempt (not a retry)", async () => {
+      mockPaymentIntentsCreate.mockResolvedValue(makeStripeIntent());
+      repo.create.mockResolvedValue(makePaymentRow());
+      repo.findByReservationId.mockResolvedValue(undefined);
+
+      await service.initiate(INITIATE_DTO);
+
+      expect(booking.submitReservation).toHaveBeenCalledWith("res-uuid");
+      expect(booking.reholdReservation).not.toHaveBeenCalled();
+    });
+
+    it("calls reholdReservation then submitReservation on retry", async () => {
+      mockPaymentIntentsCreate.mockResolvedValue(makeStripeIntent());
+      repo.create.mockResolvedValue(makePaymentRow());
+      // Simulate an existing prior payment row → isRetry = true
+      repo.findByReservationId.mockResolvedValue(
+        makePaymentRow({ status: "failed" }),
+      );
+
+      await service.initiate(INITIATE_DTO);
+
+      expect(booking.reholdReservation).toHaveBeenCalledWith("res-uuid");
+      expect(booking.submitReservation).toHaveBeenCalledWith("res-uuid");
+    });
   });
 
   // ─── handleWebhook ────────────────────────────────────────────────────────
@@ -257,6 +283,23 @@ describe("PaymentsService", () => {
           data: { object: makeStripeIntent() },
         });
         booking.confirmReservation.mockRejectedValue(new Error("unavailable"));
+
+        await expect(
+          service.handleWebhook(rawBody, sig),
+        ).resolves.not.toThrow();
+      });
+
+      it("logs err.cause when confirmReservation throws UpstreamServiceError", async () => {
+        mockWebhooksConstructEvent.mockReturnValue({
+          type: "payment_intent.succeeded",
+          data: { object: makeStripeIntent() },
+        });
+        booking.confirmReservation.mockRejectedValue(
+          new UpstreamServiceError(
+            "booking-service",
+            new Error("connection refused"),
+          ),
+        );
 
         await expect(
           service.handleWebhook(rawBody, sig),
@@ -357,6 +400,23 @@ describe("PaymentsService", () => {
         await service.handleWebhook(rawBody, sig);
 
         expect(booking.confirmReservation).not.toHaveBeenCalled();
+      });
+
+      it("logs err.cause when failReservation throws UpstreamServiceError", async () => {
+        mockWebhooksConstructEvent.mockReturnValue({
+          type: "payment_intent.payment_failed",
+          data: { object: makeStripeIntent() },
+        });
+        booking.failReservation.mockRejectedValue(
+          new UpstreamServiceError(
+            "booking-service",
+            new Error("connection refused"),
+          ),
+        );
+
+        await expect(
+          service.handleWebhook(rawBody, sig),
+        ).resolves.not.toThrow();
       });
     });
 

--- a/services/payment-service/src/payments/payments.service.ts
+++ b/services/payment-service/src/payments/payments.service.ts
@@ -6,7 +6,9 @@ import {
 } from "@nestjs/common";
 import Stripe from "stripe";
 import { PaymentsRepository } from "./payments.repository.js";
-import { EmailService } from "./email.service.js";
+import { BookingClient } from "../clients/booking.client.js";
+import { NotificationClient } from "../clients/notification.client.js";
+import { UpstreamServiceError } from "../clients/upstream-service.error.js";
 import { InitiatePaymentDto } from "./dto/initiate-payment.dto.js";
 
 // Minimal shapes extracted from the Stripe SDK objects we actually use.
@@ -23,16 +25,14 @@ interface StripePaymentIntent {
 export class PaymentsService {
   private readonly logger = new Logger(PaymentsService.name);
   private readonly stripe: InstanceType<typeof Stripe>;
-  private readonly bookingServiceUrl: string;
 
   constructor(
     private readonly repo: PaymentsRepository,
-    private readonly email: EmailService,
+    private readonly booking: BookingClient,
+    private readonly notifications: NotificationClient,
   ) {
     const secretKey = process.env.STRIPE_SECRET_KEY ?? "";
     this.stripe = new Stripe(secretKey);
-    this.bookingServiceUrl =
-      process.env.BOOKING_SERVICE_URL ?? "http://localhost:3004";
   }
 
   async initiate(dto: InitiatePaymentDto) {
@@ -115,9 +115,16 @@ export class PaymentsService {
       stripe_payment_method_id: paymentMethodId,
     });
 
-    await this.confirmBooking(reservationId);
+    await this.booking
+      .confirmReservation(reservationId)
+      .catch((err: unknown) => {
+        const detail = err instanceof UpstreamServiceError ? err.cause : err;
+        this.logger.error(
+          `Failed to confirm booking ${reservationId}: ${String(detail)}`,
+        );
+      });
 
-    await this.email
+    await this.notifications
       .sendPaymentSucceeded({
         to: guestEmail,
         reservationId,
@@ -138,28 +145,19 @@ export class PaymentsService {
       failure_reason: reason,
     });
 
-    await this.email
+    await this.booking
+      .failReservation(reservationId, reason)
+      .catch((err: unknown) => {
+        const detail = err instanceof UpstreamServiceError ? err.cause : err;
+        this.logger.error(
+          `Failed to mark reservation ${reservationId} as failed: ${String(detail)}`,
+        );
+      });
+
+    await this.notifications
       .sendPaymentFailed({ to: guestEmail, reservationId, reason })
       .catch((err) =>
         this.logger.error(`Failed to send failure email: ${err}`),
       );
-  }
-
-  private async confirmBooking(reservationId: string): Promise<void> {
-    try {
-      const res = await fetch(
-        `${this.bookingServiceUrl}/reservations/${reservationId}/confirm`,
-        { method: "PATCH" },
-      );
-      if (!res.ok) {
-        this.logger.error(
-          `Failed to confirm booking ${reservationId}: ${res.status}`,
-        );
-      } else {
-        this.logger.log(`Booking confirmed: ${reservationId}`);
-      }
-    } catch (err) {
-      this.logger.error(`Error confirming booking ${reservationId}: ${err}`);
-    }
   }
 }

--- a/services/payment-service/src/payments/payments.service.ts
+++ b/services/payment-service/src/payments/payments.service.ts
@@ -38,6 +38,15 @@ export class PaymentsService {
   async initiate(dto: InitiatePaymentDto) {
     const amountCents = Math.round(dto.amountUsd * 100);
 
+    // Determine if this is a retry (prior failed attempt exists)
+    const existing = await this.repo.findByReservationId(dto.reservationId);
+    const isRetry = !!existing;
+
+    // Re-acquire inventory hold before creating a new Stripe intent on retry
+    if (isRetry) {
+      await this.booking.reholdReservation(dto.reservationId);
+    }
+
     const intent = await this.stripe.paymentIntents.create({
       amount: amountCents,
       currency: dto.currency.toLowerCase(),
@@ -47,6 +56,9 @@ export class PaymentsService {
       },
       receipt_email: dto.guestEmail,
     });
+
+    // Transition held → submitted
+    await this.booking.submitReservation(dto.reservationId);
 
     const payment = await this.repo.create({
       reservation_id: dto.reservationId,


### PR DESCRIPTION
## Resumen

Este PR refactoriza el flujo de reservas en tres capas: máquina de estados del `booking-service`, arquitectura de clientes del `payment-service`, y la nomenclatura de estados a lo largo de todo el sistema.

### booking-service — Máquina de estados

- **Nuevos estados**: `failed` (disparado por Stripe) y `cancelled` (disparado por el usuario), ambos con columna `reason TEXT NULL` para capturar el motivo
- **Renombrado de estados** para mayor claridad semántica:
  - `on_hold` → `held` (la sala está bloqueada, el usuario está en checkout)
  - `pending` → `submitted` (pago enviado a Stripe, esperando webhook)
- **`PATCH /:id/fail`**: transiciona `submitted` → `failed`, libera el hold de inventario con `unhold()`
- **`PATCH /:id/cancel`**: cancela desde cualquier estado no terminal; usa transacción Kysely con `FOR UPDATE` para evitar race condition con el webhook de confirmación de Stripe; enruta la operación de inventario según el estado previo (`unhold` / `release` / no-op)
- **Migraciones**:
  - `003`: agrega columna `reason`
  - `004`: renombra los valores de estado en filas existentes
  - `005`: recrea el índice único parcial apuntando a `WHERE status = 'held'` (el anterior con `'pending'` quedaba muerto tras la migración 004)

### payment-service — ClientsModule

- Elimina `EmailService` local; delega el envío de correos a `notification-service` vía HTTP
- Extrae `BookingClient` y `NotificationClient` a un `ClientsModule` reutilizable, siguiendo el mismo patrón que `booking-service`
- `failReservation(id, reason)` ahora propaga el mensaje de error real de Stripe al `booking-service` en lugar de un texto genérico

### notification-service

- Agrega campo `html` opcional en `POST /notifications/send` para permitir correos con formato HTML

### performance-tests

- Actualiza todas las aserciones de estado en `smoke/booking.js` (`on_hold` → `held`, `pending` → `submitted`)

## Plan de pruebas

- [ ] `nx build booking-service` pasa sin errores de TypeScript
- [ ] `nx test booking-service` — 197/197 tests en verde
- [ ] `nx test payment-service` — todos los tests en verde
- [ ] Migrar la base de datos local y verificar que los estados existentes se renombran correctamente
- [ ] Probar flujo completo con Stripe CLI: `held` → `submitted` → `confirmed` / `failed`
- [ ] Probar cancelación desde los estados `held`, `submitted` y `confirmed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)