### PR TITLE
feat(e2e): boilerplate de pruebas e2e con Maestro para la app mobile

### DIFF
--- a/.claude/commands/e2e.md
+++ b/.claude/commands/e2e.md
@@ -1,0 +1,48 @@
+# E2E Testing (Maestro — Mobile)
+
+E2E tests live under `e2e/mobile/`. A sibling `e2e/web/` for Playwright is planned but not yet implemented.
+
+## Folder layout
+
+```
+e2e/
+└── mobile/
+    ├── config.yaml                        # shared appId (com.travelhub.mobile)
+    ├── flows/
+    │   └── register.yaml                  # registration happy-path scenario
+    └── utils/
+        ├── navigate-to-register.yaml      # sub-flow: home → Account screen → Register
+        └── generate-test-email.js         # generates a unique timestamped email via runScript
+```
+
+## Prerequisites
+
+```bash
+brew install maestro          # once per machine
+maestro --version             # verify
+nx run-ios mobile             # build & launch on iOS simulator (must be running before test)
+```
+
+## Running locally
+
+```bash
+pnpm e2e:mobile               # run all flows in e2e/mobile/flows/
+pnpm e2e:mobile:register      # run the registration flow only
+pnpm e2e:mobile:record        # record a video of the registration flow
+nx e2e mobile                 # same as e2e:mobile via Nx
+```
+
+## Key design decisions
+
+- **`openLink: travelhub:///account`** — used instead of tapping the tab bar. iOS 26's Liquid Glass tab bar is not traversable by Maestro's XCUITest driver regardless of `testID`, `tabBarTestID`, or text matching. Deep links via Expo Router's scheme are the reliable alternative.
+- **`runScript` for unique emails** — `utils/generate-test-email.js` sets `output.TEST_EMAIL` to `testuser+<timestamp>@example.com` so each run registers a fresh account. Reference it in flows as `${output.TEST_EMAIL}`.
+- **`textContentType="oneTimeCode"`** on both password fields in `mobile/app/(auth)/register.tsx` — suppresses iOS's "Use Strong Password?" system sheet, which otherwise blocks `inputText`.
+- **`register-title` testID** on the "Create account" heading — tapped after the confirm-password `inputText` to dismiss the keyboard before the checkbox tap, since `hideKeyboard` is not supported by React Native Paper inputs and the keyboard would otherwise intercept subsequent taps.
+- **`autoCorrect={false}`** added to firstName and lastName fields — prevents iOS autocorrect from silently rewriting character-by-character input.
+
+## Adding a new flow
+
+1. Create `e2e/mobile/flows/<name>.yaml` with an `appId` config section and `---` separator.
+2. Extract any reusable navigation into `e2e/mobile/utils/`.
+3. Add testIDs to source components as needed — keep additions minimal and co-located with the flow they support.
+4. Run with `pnpm e2e:mobile` to verify all flows still pass.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,10 @@ Prettier settings: single quotes, trailing commas.
 
 `.github/workflows/ci.yml` runs on push to `main` and on pull requests. It uses `nx affected` for lint/build/test so only changed projects run in CI. Node is provided via `.nvmrc` (Node 24). `NX_DAEMON=false` and `NX_TUI=false` are set for CI stability. Uses `pnpm install --frozen-lockfile` for clean installs.
 
+## E2E Testing (Mobile — Maestro)
+
+> Use `/e2e` for Maestro prerequisites, flow layout, run commands, and key design decisions (deep-link navigation, unique email generation, iOS keyboard quirks).
+
 ## Performance Testing
 
 > Use `/perf-test` for k6 scenario layout, local run commands, and GitHub Actions workflow details.

--- a/e2e/mobile/config.yaml
+++ b/e2e/mobile/config.yaml
@@ -1,0 +1,1 @@
+appId: com.travelhub.mobile

--- a/e2e/mobile/flows/register.yaml
+++ b/e2e/mobile/flows/register.yaml
@@ -1,0 +1,50 @@
+# E2E scenario: New user registration happy path.
+# Launches app cold, navigates to Register, fills all fields,
+# accepts terms, submits, asserts the success screen.
+---
+appId: com.travelhub.mobile
+env:
+  FIRST_NAME: "Test"
+  LAST_NAME: "User"
+  TEST_PASSWORD: "Test1234!"
+---
+- runScript: "../utils/generate-test-email.js"
+
+- launchApp:
+    clearState: true
+
+- assertVisible:
+    id: "input-city"
+
+- runFlow: "../utils/navigate-to-register.yaml"
+
+- tapOn:
+    id: "input-firstName"
+- inputText: ${FIRST_NAME}
+
+- tapOn:
+    id: "input-lastName"
+- inputText: ${LAST_NAME}
+
+- tapOn:
+    id: "input-email"
+- inputText: ${output.TEST_EMAIL}
+
+- tapOn:
+    id: "input-password"
+- inputText: ${TEST_PASSWORD}
+
+- tapOn:
+    id: "input-confirmPassword"
+- inputText: ${TEST_PASSWORD}
+- tapOn:
+    id: "register-title"
+
+- tapOn:
+    id: "checkbox-terms"
+
+- tapOn:
+    id: "btn-submit"
+
+- assertVisible:
+    id: "btn-explore"

--- a/e2e/mobile/utils/generate-test-email.js
+++ b/e2e/mobile/utils/generate-test-email.js
@@ -1,0 +1,1 @@
+output.TEST_EMAIL = 'testuser+' + Date.now() + '@example.com';

--- a/e2e/mobile/utils/navigate-to-register.yaml
+++ b/e2e/mobile/utils/navigate-to-register.yaml
@@ -1,0 +1,12 @@
+# Precondition: app is open on the tabs layout (Search/Home screen visible).
+# Postcondition: Register screen is visible (input-firstName present).
+appId: com.travelhub.mobile
+---
+- openLink: travelhub:///account
+- assertVisible:
+    id: "btn-signup"
+- tapOn:
+    id: "btn-signup"
+- assertVisible:
+    id: "input-firstName"
+- waitForAnimationToEnd

--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -82,7 +82,7 @@ export default function RegisterScreen() {
         <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
           <AppCard style={styles.card}>
 
-          <Text variant="headlineSmall" style={[styles.heading, { color: theme.colors.onBackground }]}>
+          <Text variant="headlineSmall" style={[styles.heading, { color: theme.colors.onBackground }]} testID="register-title">
             {t('register.heading')}
           </Text>
 
@@ -97,6 +97,7 @@ export default function RegisterScreen() {
               onChangeText={update('firstName')}
               mode="outlined"
               autoCapitalize="words"
+              autoCorrect={false}
               left={<TextInput.Icon icon="account-outline" />}
               style={styles.input}
               error={!!errors.firstName}
@@ -112,6 +113,7 @@ export default function RegisterScreen() {
               onChangeText={update('lastName')}
               mode="outlined"
               autoCapitalize="words"
+              autoCorrect={false}
               left={<TextInput.Icon icon="account-outline" />}
               style={styles.input}
               error={!!errors.lastName}
@@ -144,6 +146,7 @@ export default function RegisterScreen() {
               onChangeText={update('password')}
               mode="outlined"
               secureTextEntry={!showPassword}
+              textContentType="oneTimeCode"
               autoCapitalize="none"
               autoCorrect={false}
               left={<TextInput.Icon icon="lock-outline" />}
@@ -151,6 +154,7 @@ export default function RegisterScreen() {
                 <TextInput.Icon
                   icon={showPassword ? 'eye-off-outline' : 'eye-outline'}
                   onPress={() => setShowPassword(v => !v)}
+                  testID="btn-toggle-password"
                 />
               }
               style={styles.input}
@@ -167,6 +171,7 @@ export default function RegisterScreen() {
               onChangeText={update('confirmPassword')}
               mode="outlined"
               secureTextEntry={!showConfirm}
+              textContentType="oneTimeCode"
               autoCapitalize="none"
               autoCorrect={false}
               left={<TextInput.Icon icon="lock-check-outline" />}
@@ -174,6 +179,7 @@ export default function RegisterScreen() {
                 <TextInput.Icon
                   icon={showConfirm ? 'eye-off-outline' : 'eye-outline'}
                   onPress={() => setShowConfirm(v => !v)}
+                  testID="btn-toggle-confirm"
                 />
               }
               style={styles.input}
@@ -189,6 +195,7 @@ export default function RegisterScreen() {
               onPress={() => setAccepted(v => !v)}
               color={theme.colors.primary}
               uncheckedColor="#9ca3af"
+              testID="checkbox-terms"
             />
             <Text variant="bodySmall" style={[styles.checkboxLabel, { color: theme.colors.onSurfaceVariant }]}>
               {t('register.acceptTerms')}

--- a/mobile/project.json
+++ b/mobile/project.json
@@ -57,6 +57,13 @@
         "jestConfig": "mobile/jest.config.js",
         "passWithNoTests": true
       }
+    },
+    "e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "maestro test e2e/mobile/flows/ --config e2e/mobile/config.yaml",
+        "cwd": "{workspaceRoot}"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "infra:up": "cd pulumi && pulumi up",
     "infra:down": "cd pulumi && pulumi destroy",
     "deploy:frontend": "node scripts/deploy-frontend.mjs",
-    "prepare": "husky"
+    "prepare": "husky",
+    "e2e:mobile": "maestro test e2e/mobile/flows/ --config e2e/mobile/config.yaml",
+    "e2e:mobile:register": "maestro test e2e/mobile/flows/register.yaml --config e2e/mobile/config.yaml",
+    "e2e:mobile:record": "maestro record e2e/mobile/flows/register.yaml --config e2e/mobile/config.yaml"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## Descripción

Agrega la infraestructura base de pruebas end-to-end con Maestro bajo `e2e/mobile/`, siguiendo la estructura planificada para alojar también `e2e/web/` (Playwright) en el futuro.

El caso inicial cubre el flujo de registro de usuario feliz: lanzar la app en frío → navegar a la pantalla de registro → llenar todos los campos → aceptar términos → enviar → verificar la pantalla de éxito.

**Cambios principales:**
- `e2e/mobile/` — estructura de carpetas con `config.yaml`, `flows/register.yaml` y utilidades reutilizables
- `mobile/app/(auth)/register.tsx` — `testID`s adicionales y ajustes de comportamiento de teclado para compatibilidad con Maestro en iOS 26
- `mobile/project.json` — target `e2e` con `nx:run-commands`
- `package.json` — scripts `e2e:mobile`, `e2e:mobile:register`, `e2e:mobile:record`
- `.claude/commands/e2e.md` — comando `/e2e` con documentación del setup
- `CLAUDE.md` — referencia a `/e2e`

**Decisiones de diseño no obvias:**
- Se usa `openLink: travelhub:///account` en lugar de tap en la tab bar — iOS 26 Liquid Glass hace que los ítems del tab bar no sean traversables por XCUITest de Maestro
- `textContentType="oneTimeCode"` en los campos de contraseña para suprimir el sheet "Use Strong Password?" de iOS
- `testID="register-title"` en el heading del formulario como área segura para descartar el teclado antes de tocar el checkbox
- Email único por ejecución vía `runScript` + `output.TEST_EMAIL = 'testuser+' + Date.now() + '@example.com'`

## Tipo de cambio
- [x] Nueva funcionalidad
- [ ] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [ ] Infraestructura / configuración

## Cómo probar

```bash
brew install maestro       # una vez por máquina
nx run-ios mobile          # lanzar simulador iOS
pnpm e2e:mobile:register   # ejecutar el flujo de registro
```

El flujo debe completarse en ~35s y terminar en la pantalla de éxito (`btn-explore` visible).

## Issues relacionados
Parte de #154

## Checklist
- [x] El código compila sin errores
- [x] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [x] El linter no reporta errores (`pnpm run lint`)