### PR TITLE
fix(frontend): evitar URL malformada al redirigir a /login tras 401

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useNavigate } from '@tanstack/react-router';
 import { AuthContext } from './auth-context';
 import type { AuthUser } from './auth-context';
 import { setOnUnauthorizedHandler } from '../utils/authBridge';
@@ -23,19 +22,20 @@ function loadFromStorage(): AuthState {
 }
 
 function AuthBridgeBinder({ logout }: { logout: () => void }) {
-  const navigate = useNavigate();
-  const navigateRef = useRef(navigate);
   const logoutRef = useRef(logout);
 
   useEffect(() => {
-    navigateRef.current = navigate;
     logoutRef.current = logout;
   });
 
   useEffect(() => {
     setOnUnauthorizedHandler(() => {
       logoutRef.current();
-      void navigateRef.current({ to: '/login' });
+      // Full URL replace — hash router's navigate() only touches the hash, so
+      // if the path is already e.g. '/login' the URL ends up '/login#/login'.
+      if (typeof window !== 'undefined') {
+        window.location.replace(`${window.location.origin}/#/login`);
+      }
     });
     return () => setOnUnauthorizedHandler(null);
   }, []);

--- a/frontend/src/pages/MfaPage.spec.tsx
+++ b/frontend/src/pages/MfaPage.spec.tsx
@@ -12,6 +12,11 @@ const mockLogin = jest.fn();
 jest.mock('@tanstack/react-router', () => ({
   useNavigate: () => mockNavigate,
   useSearch: (...args: unknown[]) => mockUseSearch(...args),
+  Link: ({ to, children, ...rest }: { to: string; children: React.ReactNode } & Record<string, unknown>) => (
+    <a href={`#${to}`} {...rest}>
+      {children}
+    </a>
+  ),
 }));
 
 jest.mock('../hooks/useAuth', () => ({

--- a/frontend/src/pages/MfaPage.tsx
+++ b/frontend/src/pages/MfaPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useNavigate, useSearch } from '@tanstack/react-router';
+import { Link, useNavigate, useSearch } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import Button from '@mui/material/Button';
 import Alert from '@mui/material/Alert';
@@ -90,9 +90,9 @@ export default function MfaPage() {
             {showRetryLink && (
               <span>
                 {' '}
-                <a href="/login" className="underline">
+                <Link to="/login" className="underline">
                   {t('mfa.try_again_link')}
-                </a>
+                </Link>
               </span>
             )}
           </Alert>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { Link as RouterLink, useNavigate } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 import Button from '@mui/material/Button';
 import Checkbox from '@mui/material/Checkbox';
@@ -153,7 +153,7 @@ export default function RegisterPage() {
         <h1 className="text-2xl font-bold text-gray-900 mb-1">{t('register.title')}</h1>
         <p className="text-sm text-gray-600 mb-6">
           {t('register.already_have_account')}{' '}
-          <Link href="/login" underline="hover">
+          <Link component={RouterLink} to="/login" underline="hover">
             {t('register.login_link')}
           </Link>
         </p>


### PR DESCRIPTION
## Descripción
Al recibir un 401, la app redirigía a una URL malformada del estilo `http://localhost:4200/login#/login`. El router usa `createHashHistory`, así que `navigate({to:'/login'})` solo actualiza el hash; si el path del navegador ya era `/login` (porque algún enlace lo había forzado), terminaba duplicado.

Cambios:
- `AuthContext`: el handler de 401 ahora hace `window.location.replace(origin + '/#/login')` para resetear path y hash de una sola vez (y de paso limpia estado en memoria al recargar).
- `RegisterPage.tsx`: `<Link href="/login">` (MUI, navegación full-page) → `<Link component={RouterLink} to="/login">`.
- `MfaPage.tsx`: `<a href="/login">` crudo → `<Link to="/login">` de TanStack Router.
- `MfaPage.spec.tsx`: el mock de `@tanstack/react-router` expone ahora `Link`.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [ ] Infraestructura / configuración

## Cómo probar
1. `pnpm run serve:frontend` y autenticarse normalmente.
2. Forzar un 401 (por ejemplo, borrar `auth_token` en localStorage o esperar a que expire) y disparar cualquier query/mutación.
3. Verificar que la URL final es `http://localhost:4200/#/login` (sin path duplicado).
4. Repetir desde la página de Registro pulsando el enlace "Iniciar sesión" y desde `MfaPage` pulsando "Volver a intentar". En ambos casos la URL debe quedar `http://localhost:4200/#/login`, no `/login#/login`.

## Issues relacionados
N/A

## Checklist
- [x] El código compila sin errores
- [x] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [x] El linter no reporta errores (`pnpm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)