### PR TITLE
chore(frontend): TaxTab informativo, sin botón "nueva regla"

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -544,8 +544,7 @@
         },
         "tax": {
           "title": "Tax rules · {{city}}, {{country}}",
-          "new_rule": "New rule",
-          "banner": "These rules apply automatically to all reservations in {{city}}.",
+          "banner": "TravelHub administers regulatory tax rules for {{city}}. They are reflected in displayed search prices and itemized at checkout.",
           "load_error": "Failed to load tax rules.",
           "no_rules": "No rules configured for {{city}}.",
           "all_cities": "All",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -544,8 +544,7 @@
         },
         "tax": {
           "title": "Reglas de impuesto · {{city}}, {{country}}",
-          "new_rule": "Nueva regla",
-          "banner": "Estas reglas se aplican automáticamente a todas las reservas en {{city}}.",
+          "banner": "TravelHub administra las reglas de impuesto regulatorias para {{city}}. Se reflejan en los precios mostrados en la búsqueda y se desglosan al confirmar la reserva.",
           "load_error": "No se pudieron cargar las reglas de impuesto.",
           "no_rules": "Sin reglas configuradas para {{city}}.",
           "all_cities": "Todas",

--- a/frontend/src/pages/partner/property/edit/TaxTab.tsx
+++ b/frontend/src/pages/partner/property/edit/TaxTab.tsx
@@ -3,21 +3,17 @@ import { useTranslation } from 'react-i18next';
 import {
   Alert,
   Box,
-  Button,
   Card,
   Chip,
   CircularProgress,
-  Stack,
   Table,
   TableBody,
   TableCell,
   TableContainer,
   TableHead,
   TableRow,
-  Tooltip,
   Typography,
 } from '@mui/material';
-import AddIcon from '@mui/icons-material/Add';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import type { TaxRule } from '../../../../utils/queries';
 import { KpiBlock } from './components';
@@ -48,18 +44,9 @@ export default function TaxTab({ country, countryLabel, city, rules, isLoading, 
 
   return (
     <Card sx={{ p: 3 }}>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 1.5 }}>
-        <Typography sx={{ fontSize: 16, fontWeight: 600, color: '#1a2332' }}>
-          {t('partner.properties.edit.tax.title', { city, country: countryLabel })}
-        </Typography>
-        <Tooltip title={t('partner.properties.edit.coming_soon')}>
-          <span>
-            <Button variant="contained" size="small" startIcon={<AddIcon fontSize="small" />} disabled>
-              {t('partner.properties.edit.tax.new_rule')}
-            </Button>
-          </span>
-        </Tooltip>
-      </Stack>
+      <Typography sx={{ fontSize: 16, fontWeight: 600, color: '#1a2332', mb: 1.5 }}>
+        {t('partner.properties.edit.tax.title', { city, country: countryLabel })}
+      </Typography>
 
       <Alert severity="info" icon={<InfoOutlinedIcon fontSize="inherit" />} sx={{ fontSize: 12.5, mb: 2 }}>
         {t('partner.properties.edit.tax.banner', { city })}


### PR DESCRIPTION
## Descripción
TaxTab era de solo lectura pero mostraba un botón **Nueva regla** deshabilitado con tooltip "Próximamente", lo que sugería que los partners podrían crear reglas en el futuro. No es así: las reglas de impuesto son regulatorias (IVA, IGV, ISH, IIBB) y las administra TravelHub centralmente — el endpoint CRUD ya existe en `booking-service` para uso operativo, no para partners.

Cambios:
- Quito el botón deshabilitado y el wrapper `<Stack>` del header de `TaxTab.tsx`.
- Quito imports ya no usados (`Button`, `Stack`, `Tooltip`, `AddIcon`).
- Reescribo el banner para nombrar a TravelHub como administrador y aclarar que estas reglas se reflejan tanto en los precios de búsqueda (`room_search_index.tax_rate_pct`, vía `tax-rule-upserted.handler.ts`) como en el desglose itemizado al confirmar reserva (`FareCalculatorService`).
- Elimino la clave i18n `partner.properties.edit.tax.new_rule` (sin consumidores tras quitar el botón).

El path de lectura existente (`fetchTaxRulesByCountry` → `GET /api/booking/tax-rules`) no cambia.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [ ] Corrección de error
- [x] Refactor
- [ ] Documentación
- [ ] Infraestructura / configuración

## Cómo probar
1. Levantar gateway, auth, booking y frontend: `pnpm run serve:api-gateway`, `serve:auth`, `serve:booking`, `serve:frontend`.
2. Asegurar que booking-service esté migrado y semillado (ver `/db`).
3. Loguearse como partner, abrir una propiedad y entrar al tab **Reglas de impuesto**.
4. Confirmar:
   - [ ] Las reglas siguen cargándose para el país de la propiedad (ej. AR → IVA 21% + IIBB 3%).
   - [ ] Los KPIs (Impuesto efectivo, Reglas activas, País) se calculan correctamente.
   - [ ] El botón "Nueva regla" ya no aparece.
   - [ ] El banner muestra el nuevo texto en español y en inglés (toggle de idioma).
5. Sanity cross-surface: buscar una propiedad en el mismo país y verificar que `ResultCard` muestre la etiqueta "incl. taxes" sobre un total ≈ `noches × base × (1 + tasa%)`.

## Issues relacionados
Closes #45

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [ ] Se ejecutaron las pruebas existentes sin regresiones (\`pnpm test\`)
- [x] El linter no reporta errores (\`pnpm exec nx lint frontend\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)