### PR TITLE
Feature/jaime/27 reembolsos automatizados

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -309,7 +309,26 @@
       "title": "Cancel reservation?",
       "body": "This action cannot be undone. Are you sure you want to cancel this reservation?",
       "keep": "Keep reservation",
-      "confirm": "Yes, cancel"
+      "confirm": "Yes, cancel",
+      "loading_quote": "Calculating refund based on the cancellation policy…",
+      "policy_full": "You will receive a full refund of {{amount}} on the original payment method.",
+      "policy_partial": "{{days}} days from check-in qualifies for a partial refund: {{amount}}.",
+      "policy_none": "This cancellation does not qualify for a refund per the policy."
+    },
+    "refund_result": {
+      "title_success": "Refund in progress",
+      "title_skipped": "Reservation cancelled without refund",
+      "amount": "Amount to be credited",
+      "comprobante": "Receipt",
+      "eta": "Estimated time to credit: 5 to 10 business days on the original payment method.",
+      "policy_skipped": "Your cancellation is recorded. Per the policy, no refund applies.",
+      "email_notice": "We sent you an email with the refund details.",
+      "close": "Got it"
+    },
+    "refund_failed": {
+      "title": "We could not process the refund automatically",
+      "body": "Your reservation was cancelled, but the payment gateway rejected the refund. Customer Service was notified and will reach out.",
+      "close": "Got it"
     }
   },
   "booking": {

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -309,7 +309,26 @@
       "title": "¿Cancelar reservación?",
       "body": "Esta acción no se puede deshacer. ¿Estás seguro de que deseas cancelar esta reservación?",
       "keep": "Mantener",
-      "confirm": "Sí, cancelar"
+      "confirm": "Sí, cancelar",
+      "loading_quote": "Calculando reembolso según política de cancelación…",
+      "policy_full": "Recibirás un reembolso total de {{amount}} en el medio de pago original.",
+      "policy_partial": "A {{days}} días del check-in se aplica reembolso parcial: {{amount}}.",
+      "policy_none": "Esta cancelación no genera reembolso según la política."
+    },
+    "refund_result": {
+      "title_success": "Reembolso en proceso",
+      "title_skipped": "Reserva cancelada sin reembolso",
+      "amount": "Importe a acreditar",
+      "comprobante": "Comprobante",
+      "eta": "Tiempo estimado de acreditación: 5 a 10 días hábiles en el medio de pago original.",
+      "policy_skipped": "Tu cancelación quedó registrada. Según la política, no corresponde reembolso.",
+      "email_notice": "Te enviamos un correo con los detalles del reembolso.",
+      "close": "Entendido"
+    },
+    "refund_failed": {
+      "title": "No pudimos procesar el reembolso automáticamente",
+      "body": "Tu reserva fue cancelada, pero la pasarela de pago rechazó el reembolso. Servicio al Cliente fue notificado y se pondrá en contacto contigo.",
+      "close": "Entendido"
     }
   },
   "booking": {

--- a/frontend/src/pages/trips/index.spec.tsx
+++ b/frontend/src/pages/trips/index.spec.tsx
@@ -318,14 +318,29 @@ describe('TripsPage', () => {
   });
 
   describe('cancel flow', () => {
-    async function setupWithCancellable(status = 'confirmed') {
+    const REFUND_QUOTE = { policy: 'full_refund', refundableUsd: 300, daysUntilCheckIn: 14 };
+
+    async function setupWithCancellable(
+      status = 'confirmed',
+      cancelOutcome: Record<string, unknown> = {
+        status: 'cancelled',
+        refund: { status: 'succeeded', policy: 'full_refund', refundedUsd: 300, externalRef: 're_test_xyz', adjustmentId: 'adj-1' },
+      },
+      quote: Record<string, unknown> = REFUND_QUOTE,
+    ) {
       useAuth.mockReturnValue({ token: TOKEN, user: USER });
-      (global.fetch as jest.Mock)
-        .mockResolvedValueOnce({
+      (global.fetch as jest.Mock).mockImplementation((url: string) => {
+        if (url.includes('/refund-quote')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(quote) });
+        }
+        if (url.includes('/cancel')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve(cancelOutcome) });
+        }
+        return Promise.resolve({
           ok: true,
           json: () => Promise.resolve({ reservations: [makeReservation(status)] }),
-        })
-        .mockResolvedValue({ ok: true });
+        });
+      });
       renderPage();
       return screen.findByRole('button', { name: es.trips.card.cancel });
     }
@@ -381,6 +396,58 @@ describe('TripsPage', () => {
       const btn = await setupWithCancellable('submitted');
       fireEvent.click(btn);
       expect(await screen.findByText(es.trips.cancel_dialog.title)).toBeInTheDocument();
+    });
+
+    it('shows the refund-policy preview inside the cancel dialog', async () => {
+      const btn = await setupWithCancellable();
+      fireEvent.click(btn);
+      await screen.findByText(es.trips.cancel_dialog.title);
+      // Renders an interpolated string like "Recibirás un reembolso total de USD 300.00 …"
+      expect(
+        await screen.findByText(/reembolso total/i),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the refund result dialog with comprobante and ETA after a successful cancel', async () => {
+      const btn = await setupWithCancellable();
+      fireEvent.click(btn);
+      await screen.findByText(es.trips.cancel_dialog.title);
+      fireEvent.click(screen.getByRole('button', { name: es.trips.cancel_dialog.confirm }));
+
+      expect(
+        await screen.findByText(es.trips.refund_result.title_success),
+      ).toBeInTheDocument();
+      expect(screen.getByText('re_test_xyz')).toBeInTheDocument();
+      expect(screen.getByText(es.trips.refund_result.eta)).toBeInTheDocument();
+    });
+
+    it('shows the gateway-failure dialog when refund is null on a confirmed cancellation', async () => {
+      const btn = await setupWithCancellable('confirmed', {
+        status: 'cancelled',
+        refund: null,
+      });
+      fireEvent.click(btn);
+      await screen.findByText(es.trips.cancel_dialog.title);
+      fireEvent.click(screen.getByRole('button', { name: es.trips.cancel_dialog.confirm }));
+
+      expect(
+        await screen.findByText(es.trips.refund_failed.title),
+      ).toBeInTheDocument();
+    });
+
+    it('does not pop the gateway-failure dialog when prior status was submitted (no payment captured)', async () => {
+      const btn = await setupWithCancellable('submitted', {
+        status: 'cancelled',
+        refund: null,
+      });
+      fireEvent.click(btn);
+      await screen.findByText(es.trips.cancel_dialog.title);
+      fireEvent.click(screen.getByRole('button', { name: es.trips.cancel_dialog.confirm }));
+
+      await waitFor(() => {
+        expect(screen.queryByText(es.trips.cancel_dialog.title)).not.toBeInTheDocument();
+      });
+      expect(screen.queryByText(es.trips.refund_failed.title)).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/pages/trips/index.tsx
+++ b/frontend/src/pages/trips/index.tsx
@@ -8,6 +8,8 @@ import { saveCheckoutIntent } from '../../hooks/useBookingFlow';
 import {
   fetchMyReservations,
   cancelReservation,
+  fetchRefundQuote,
+  type CancelReservationOutcome,
   type ReservationListItem,
   type ReservationStatus,
 } from '../../utils/queries';
@@ -226,6 +228,8 @@ export default function TripsPage() {
   const queryClient = useQueryClient();
 
   const [cancelTarget, setCancelTarget] = useState<string | null>(null);
+  const [refundResult, setRefundResult] = useState<CancelReservationOutcome | null>(null);
+  const [refundFailedOpen, setRefundFailedOpen] = useState(false);
 
   const { data: reservations = [], isPending, isError } = useQuery({
     queryKey: ['my-reservations', user?.id],
@@ -233,14 +237,29 @@ export default function TripsPage() {
     enabled: !!token && !!user,
   });
 
+  const { data: refundQuote, isLoading: quoteLoading } = useQuery({
+    queryKey: ['refund-quote', cancelTarget],
+    queryFn: () => fetchRefundQuote(cancelTarget!, token!),
+    enabled: !!cancelTarget && !!token,
+  });
+
   const { mutate: doCancel, isPending: cancelling, variables: cancellingId } = useMutation({
     mutationFn: (id: string) => cancelReservation(id, token!, 'user_requested'),
-    onSuccess: (_, id) => {
+    onSuccess: (outcome, id) => {
       queryClient.setQueryData<ReservationListItem[]>(
         ['my-reservations', user?.id],
         (prev) => prev?.map((r) => (r.id === id ? { ...r, status: 'cancelled' as ReservationStatus } : r)),
       );
       setCancelTarget(null);
+      // A null refund either means there was nothing to refund (held/submitted)
+      // or the gateway rejected the request — only the latter requires the
+      // alert dialog. We disambiguate by checking the prior status of the row.
+      const prior = reservations.find((r) => r.id === id);
+      if (outcome.refund) {
+        setRefundResult(outcome);
+      } else if (prior?.status === 'confirmed') {
+        setRefundFailedOpen(true);
+      }
     },
   });
 
@@ -405,7 +424,10 @@ export default function TripsPage() {
       <Dialog open={cancelTarget !== null} onClose={() => !cancelling && setCancelTarget(null)}>
         <DialogTitle>{t('trips.cancel_dialog.title')}</DialogTitle>
         <DialogContent>
-          <DialogContentText>{t('trips.cancel_dialog.body')}</DialogContentText>
+          <DialogContentText sx={{ mb: 2 }}>{t('trips.cancel_dialog.body')}</DialogContentText>
+          <DialogContentText sx={{ fontSize: 13 }}>
+            {refundPolicyMessage(refundQuote, quoteLoading, currency, t)}
+          </DialogContentText>
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setCancelTarget(null)} disabled={cancelling}>
@@ -420,6 +442,97 @@ export default function TripsPage() {
           </Button>
         </DialogActions>
       </Dialog>
+
+      <RefundResultDialog
+        outcome={refundResult}
+        currency={currency}
+        onClose={() => setRefundResult(null)}
+      />
+
+      <Dialog open={refundFailedOpen} onClose={() => setRefundFailedOpen(false)}>
+        <DialogTitle>{t('trips.refund_failed.title')}</DialogTitle>
+        <DialogContent>
+          <DialogContentText>{t('trips.refund_failed.body')}</DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setRefundFailedOpen(false)} variant="contained">
+            {t('trips.refund_failed.close')}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </PageContainer>
+  );
+}
+
+function refundPolicyMessage(
+  quote: { policy: string; refundableUsd: number; daysUntilCheckIn: number } | undefined,
+  loading: boolean,
+  currency: ReturnType<typeof useLocale>['currency'],
+  t: (k: string, opts?: Record<string, unknown>) => string,
+): string {
+  if (loading || !quote) return t('trips.cancel_dialog.loading_quote');
+  if (quote.policy === 'full_refund') {
+    return t('trips.cancel_dialog.policy_full', {
+      amount: formatPrice(quote.refundableUsd, currency),
+    });
+  }
+  if (quote.policy === 'partial_refund') {
+    return t('trips.cancel_dialog.policy_partial', {
+      amount: formatPrice(quote.refundableUsd, currency),
+      days: quote.daysUntilCheckIn,
+    });
+  }
+  return t('trips.cancel_dialog.policy_none');
+}
+
+function RefundResultDialog({
+  outcome,
+  currency,
+  onClose,
+}: {
+  outcome: CancelReservationOutcome | null;
+  currency: ReturnType<typeof useLocale>['currency'];
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  if (!outcome?.refund) return null;
+  const { refund } = outcome;
+  const skipped = refund.status === 'skipped';
+
+  return (
+    <Dialog open onClose={onClose}>
+      <DialogTitle>
+        {skipped ? t('trips.refund_result.title_skipped') : t('trips.refund_result.title_success')}
+      </DialogTitle>
+      <DialogContent>
+        {skipped ? (
+          <DialogContentText>{t('trips.refund_result.policy_skipped')}</DialogContentText>
+        ) : (
+          <Box>
+            <DialogContentText sx={{ mb: 1.5 }}>
+              <strong>{t('trips.refund_result.amount')}: </strong>
+              {formatPrice(refund.refundedUsd, currency)}
+            </DialogContentText>
+            {refund.externalRef && (
+              <DialogContentText sx={{ mb: 1.5 }}>
+                <strong>{t('trips.refund_result.comprobante')}: </strong>
+                <Box component="span" sx={{ fontFamily: 'monospace', fontSize: 13 }}>
+                  {refund.externalRef}
+                </Box>
+              </DialogContentText>
+            )}
+            <DialogContentText sx={{ mb: 1.5 }}>{t('trips.refund_result.eta')}</DialogContentText>
+            <DialogContentText sx={{ fontSize: 13, color: '#6b7280' }}>
+              {t('trips.refund_result.email_notice')}
+            </DialogContentText>
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="contained">
+          {t('trips.refund_result.close')}
+        </Button>
+      </DialogActions>
+    </Dialog>
   );
 }

--- a/frontend/src/utils/queries.spec.ts
+++ b/frontend/src/utils/queries.spec.ts
@@ -308,13 +308,33 @@ describe('queries', () => {
   // ─── cancelReservation ──────────────────────────────────────────────────────
 
   describe('cancelReservation', () => {
-    it('resolves without a value on success', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
-      await expect(cancelReservation('r1', 'tok', 'user_requested')).resolves.toBeUndefined();
+    const refundedOutcome = {
+      status: 'cancelled',
+      refund: {
+        status: 'succeeded',
+        policy: 'full_refund',
+        refundedUsd: 522,
+        externalRef: 're_test',
+        adjustmentId: 'adj-1',
+      },
+    };
+
+    it('returns the parsed cancellation outcome including refund metadata', async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue(refundedOutcome),
+      });
+
+      await expect(cancelReservation('r1', 'tok', 'user_requested')).resolves.toEqual(
+        refundedOutcome,
+      );
     });
 
     it('sends a PATCH request with the reason in the body', async () => {
-      (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({ status: 'cancelled', refund: null }),
+      });
       await cancelReservation('r1', 'tok', 'user_requested');
       expect(global.fetch).toHaveBeenCalledWith(
         expect.stringContaining('/reservations/r1/cancel'),

--- a/frontend/src/utils/queries.ts
+++ b/frontend/src/utils/queries.ts
@@ -229,13 +229,29 @@ export async function fetchMyReservations(token: string, bookerId: string): Prom
   return Array.isArray(data) ? data : (data.reservations ?? []);
 }
 
-export async function cancelReservation(id: string, token: string, reason: string): Promise<void> {
+export interface CancelReservationOutcome {
+  status: ReservationStatus;
+  refund: {
+    status: 'succeeded' | 'skipped';
+    policy: RefundPolicy;
+    refundedUsd: number;
+    externalRef: string | null;
+    adjustmentId: string;
+  } | null;
+}
+
+export async function cancelReservation(
+  id: string,
+  token: string,
+  reason: string,
+): Promise<CancelReservationOutcome> {
   const res = await fetch(`${API_BASE}/api/booking/reservations/${id}/cancel`, {
     method: 'PATCH',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
     body: JSON.stringify({ reason }),
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json() as Promise<CancelReservationOutcome>;
 }
 
 export interface ModifyReservationInput {

--- a/services/api-gateway/eslint.config.mjs
+++ b/services/api-gateway/eslint.config.mjs
@@ -19,7 +19,7 @@ export default tseslint.config(
       },
       sourceType: 'commonjs',
       parserOptions: {
-        projectService: true,
+        project: ["./tsconfig.json", "./tsconfig.spec.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/services/api-gateway/tsconfig.json
+++ b/services/api-gateway/tsconfig.json
@@ -23,7 +23,14 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.spec.json" }]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }

--- a/services/api-gateway/tsconfig.json
+++ b/services/api-gateway/tsconfig.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist"]
+  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.spec.json" }]
 }

--- a/services/api-gateway/tsconfig.spec.json
+++ b/services/api-gateway/tsconfig.spec.json
@@ -5,12 +5,19 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolvePackageJsonExports": false,
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     "src/**/*.d.ts",
     "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }

--- a/services/auth-service/eslint.config.mjs
+++ b/services/auth-service/eslint.config.mjs
@@ -19,9 +19,7 @@ export default tseslint.config(
       },
       sourceType: 'commonjs',
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ['kysely.config.ts', 'scripts/*.ts'],
-        },
+        project: ["./tsconfig.json", "./tsconfig.spec.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/services/auth-service/tsconfig.json
+++ b/services/auth-service/tsconfig.json
@@ -23,7 +23,14 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.spec.json" }]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }

--- a/services/auth-service/tsconfig.json
+++ b/services/auth-service/tsconfig.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist"]
+  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.spec.json" }]
 }

--- a/services/auth-service/tsconfig.spec.json
+++ b/services/auth-service/tsconfig.spec.json
@@ -4,12 +4,19 @@
     "outDir": "../../dist/out-tsc",
     "module": "nodenext",
     "resolvePackageJsonExports": false,
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     "src/**/*.d.ts",
     "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }

--- a/services/booking-service/eslint.config.mjs
+++ b/services/booking-service/eslint.config.mjs
@@ -19,9 +19,7 @@ export default tseslint.config(
       },
       sourceType: 'commonjs',
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ['kysely.config.ts', 'scripts/*.ts'],
-        },
+        project: ["./tsconfig.json", "./tsconfig.spec.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/services/booking-service/src/clients/clients.module.ts
+++ b/services/booking-service/src/clients/clients.module.ts
@@ -2,10 +2,11 @@ import { Module } from "@nestjs/common";
 import { HttpModule } from "@nestjs/axios";
 import { InventoryClient } from "./inventory.client.js";
 import { PartnersClient } from "./partners.client.js";
+import { PaymentClient } from "./payment.client.js";
 
 @Module({
   imports: [HttpModule],
-  providers: [InventoryClient, PartnersClient],
-  exports: [InventoryClient, PartnersClient],
+  providers: [InventoryClient, PartnersClient, PaymentClient],
+  exports: [InventoryClient, PartnersClient, PaymentClient],
 })
 export class ClientsModule {}

--- a/services/booking-service/src/clients/payment.client.spec.ts
+++ b/services/booking-service/src/clients/payment.client.spec.ts
@@ -1,0 +1,75 @@
+import type { HttpService } from "@nestjs/axios";
+import { of, throwError } from "rxjs";
+import { PaymentClient } from "./payment.client.js";
+import { UpstreamServiceError } from "./upstream-service.error.js";
+
+function makeClient(
+  httpPost: jest.Mock = jest.fn().mockReturnValue(
+    of({
+      data: {
+        status: "succeeded",
+        policy: "full_refund",
+        refundedUsd: 100,
+        externalRef: "re_test",
+        adjustmentId: "adj-1",
+      },
+    }),
+  ),
+) {
+  const httpService = { post: httpPost } as unknown as HttpService;
+  return { client: new PaymentClient(httpService), httpPost };
+}
+
+const INPUT = {
+  reservationId: "res-uuid",
+  reason: "guest_cancelled",
+  actorId: "user-7",
+  actorRole: "guest",
+  requestIp: "10.0.0.1",
+};
+
+describe("PaymentClient.requestRefund", () => {
+  it("POSTs to /payments/:id/refund with the actor metadata in the body", async () => {
+    const { client, httpPost } = makeClient();
+
+    const result = await client.requestRefund(INPUT);
+
+    expect(httpPost).toHaveBeenCalledWith(
+      expect.stringMatching(/\/payments\/res-uuid\/refund$/),
+      {
+        reason: "guest_cancelled",
+        actorId: "user-7",
+        actorRole: "guest",
+      },
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "content-type": "application/json",
+          "x-forwarded-for": "10.0.0.1",
+        }),
+      }),
+    );
+    expect(result.externalRef).toBe("re_test");
+  });
+
+  it("omits x-forwarded-for when no IP is provided", async () => {
+    const { client, httpPost } = makeClient();
+
+    await client.requestRefund({ ...INPUT, requestIp: null });
+
+    const headers = (
+      httpPost.mock.calls[0][2] as { headers: Record<string, string> }
+    ).headers;
+    expect(headers["x-forwarded-for"]).toBeUndefined();
+  });
+
+  it("wraps downstream errors in UpstreamServiceError", async () => {
+    const httpPost = jest
+      .fn()
+      .mockReturnValue(throwError(() => new Error("connection refused")));
+    const { client } = makeClient(httpPost);
+
+    await expect(client.requestRefund(INPUT)).rejects.toThrow(
+      UpstreamServiceError,
+    );
+  });
+});

--- a/services/booking-service/src/clients/payment.client.ts
+++ b/services/booking-service/src/clients/payment.client.ts
@@ -1,0 +1,58 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { HttpService } from "@nestjs/axios";
+import { firstValueFrom } from "rxjs";
+import { UpstreamServiceError } from "./upstream-service.error.js";
+
+export interface RefundOutcome {
+  status: "succeeded" | "skipped";
+  policy: "full_refund" | "partial_refund" | "no_refund";
+  refundedUsd: number;
+  externalRef: string | null;
+  adjustmentId: string;
+}
+
+export interface RequestRefundInput {
+  reservationId: string;
+  reason: string;
+  actorId: string | null;
+  actorRole: string | null;
+  requestIp: string | null;
+}
+
+@Injectable()
+export class PaymentClient {
+  private readonly logger = new Logger(PaymentClient.name);
+  private readonly baseUrl: string;
+
+  constructor(private readonly httpService: HttpService) {
+    this.baseUrl =
+      process.env["PAYMENT_SERVICE_URL"] ?? "http://localhost:3005";
+  }
+
+  async requestRefund(input: RequestRefundInput): Promise<RefundOutcome> {
+    try {
+      const headers: Record<string, string> = {
+        "content-type": "application/json",
+      };
+      if (input.requestIp) headers["x-forwarded-for"] = input.requestIp;
+
+      const res = await firstValueFrom(
+        this.httpService.post<RefundOutcome>(
+          `${this.baseUrl}/payments/${input.reservationId}/refund`,
+          {
+            reason: input.reason,
+            actorId: input.actorId,
+            actorRole: input.actorRole,
+          },
+          { headers },
+        ),
+      );
+      return res.data;
+    } catch (err) {
+      this.logger.error(
+        `requestRefund failed for reservation ${input.reservationId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      throw new UpstreamServiceError("payment-service", err);
+    }
+  }
+}

--- a/services/booking-service/src/reservations/reservations.controller.spec.ts
+++ b/services/booking-service/src/reservations/reservations.controller.spec.ts
@@ -224,6 +224,7 @@ describe("ReservationsController", () => {
         { reason: "changed mind" },
         undefined as any,
         undefined as any,
+        undefined as any,
         "10.0.0.1",
       );
 
@@ -236,7 +237,7 @@ describe("ReservationsController", () => {
       expect(result).toBe(reservation);
     });
 
-    it("passes guest actor and forwards user-id + ip to the service", async () => {
+    it("prefers x-forwarded-for over @Ip() when both are present", async () => {
       const reservation = { id: "res-1", status: "cancelled" } as any;
       (service.cancel as jest.Mock).mockResolvedValue(reservation);
 
@@ -245,6 +246,7 @@ describe("ReservationsController", () => {
         { reason: "changed mind" },
         "guest",
         "user-7",
+        "203.0.113.5, 198.51.100.10",
         "10.0.0.1",
       );
 
@@ -252,7 +254,7 @@ describe("ReservationsController", () => {
         "res-1",
         "changed mind",
         "guest",
-        { actorId: "user-7", requestIp: "10.0.0.1" },
+        { actorId: "user-7", requestIp: "203.0.113.5" },
       );
     });
 
@@ -265,6 +267,7 @@ describe("ReservationsController", () => {
         { reason: "overbooking" },
         "partner",
         "partner-9",
+        undefined as any,
         "10.0.0.2",
       );
 

--- a/services/booking-service/src/reservations/reservations.controller.spec.ts
+++ b/services/booking-service/src/reservations/reservations.controller.spec.ts
@@ -223,26 +223,36 @@ describe("ReservationsController", () => {
         "res-1",
         { reason: "changed mind" },
         undefined as any,
+        undefined as any,
+        "10.0.0.1",
       );
 
       expect(service.cancel).toHaveBeenCalledWith(
         "res-1",
         "changed mind",
         "system",
+        { actorId: null, requestIp: "10.0.0.1" },
       );
       expect(result).toBe(reservation);
     });
 
-    it("passes guest actor when role header is 'guest'", async () => {
+    it("passes guest actor and forwards user-id + ip to the service", async () => {
       const reservation = { id: "res-1", status: "cancelled" } as any;
       (service.cancel as jest.Mock).mockResolvedValue(reservation);
 
-      await controller.cancel("res-1", { reason: "changed mind" }, "guest");
+      await controller.cancel(
+        "res-1",
+        { reason: "changed mind" },
+        "guest",
+        "user-7",
+        "10.0.0.1",
+      );
 
       expect(service.cancel).toHaveBeenCalledWith(
         "res-1",
         "changed mind",
         "guest",
+        { actorId: "user-7", requestIp: "10.0.0.1" },
       );
     });
 
@@ -250,12 +260,19 @@ describe("ReservationsController", () => {
       const reservation = { id: "res-1", status: "cancelled" } as any;
       (service.cancel as jest.Mock).mockResolvedValue(reservation);
 
-      await controller.cancel("res-1", { reason: "overbooking" }, "partner");
+      await controller.cancel(
+        "res-1",
+        { reason: "overbooking" },
+        "partner",
+        "partner-9",
+        "10.0.0.2",
+      );
 
       expect(service.cancel).toHaveBeenCalledWith(
         "res-1",
         "overbooking",
         "partner",
+        { actorId: "partner-9", requestIp: "10.0.0.2" },
       );
     });
   });

--- a/services/booking-service/src/reservations/reservations.controller.ts
+++ b/services/booking-service/src/reservations/reservations.controller.ts
@@ -91,12 +91,17 @@ export class ReservationsController {
     @Body() body: { reason: string },
     @Headers("x-user-role") role: string,
     @Headers("x-user-id") userId: string,
-    @Ip() ip: string,
+    @Headers("x-forwarded-for") forwardedFor: string,
+    @Ip() directIp: string,
   ) {
     const actor: BookingActor = role ? (role as BookingActor) : "system";
+    // booking-service runs behind api-gateway; @Ip() resolves to the gateway
+    // IP, not the original client. Prefer the left-most x-forwarded-for entry
+    // when present so the audit log records the real caller.
+    const fromHeader = forwardedFor?.split(",")[0]?.trim();
     return this.reservationsService.cancel(id, body.reason, actor, {
       actorId: userId || null,
-      requestIp: ip || null,
+      requestIp: fromHeader || directIp || null,
     });
   }
 

--- a/services/booking-service/src/reservations/reservations.controller.ts
+++ b/services/booking-service/src/reservations/reservations.controller.ts
@@ -9,6 +9,7 @@ import {
   Headers,
   HttpCode,
   HttpStatus,
+  Ip,
   Res,
 } from "@nestjs/common";
 import type { Response } from "express";
@@ -89,9 +90,14 @@ export class ReservationsController {
     @Param("id") id: string,
     @Body() body: { reason: string },
     @Headers("x-user-role") role: string,
+    @Headers("x-user-id") userId: string,
+    @Ip() ip: string,
   ) {
     const actor: BookingActor = role ? (role as BookingActor) : "system";
-    return this.reservationsService.cancel(id, body.reason, actor);
+    return this.reservationsService.cancel(id, body.reason, actor, {
+      actorId: userId || null,
+      requestIp: ip || null,
+    });
   }
 
   @Patch(":id/rehold")

--- a/services/booking-service/src/reservations/reservations.service.spec.ts
+++ b/services/booking-service/src/reservations/reservations.service.spec.ts
@@ -92,6 +92,7 @@ describe("ReservationsService", () => {
   };
   let publisher: { publish: jest.Mock };
   let partnersClient: { getCheckinKey: jest.Mock };
+  let paymentClient: { requestRefund: jest.Mock };
   let inventoryClient: {
     getRoomLocation: jest.Mock;
     getRoomDetails: jest.Mock;
@@ -136,6 +137,15 @@ describe("ReservationsService", () => {
     };
     publisher = { publish: jest.fn() };
     partnersClient = { getCheckinKey: jest.fn().mockResolvedValue("test-key") };
+    paymentClient = {
+      requestRefund: jest.fn().mockResolvedValue({
+        status: "succeeded",
+        policy: "full_refund",
+        refundedUsd: 522,
+        externalRef: "re_test_123",
+        adjustmentId: "adj-uuid",
+      }),
+    };
     reservationsRepo = {
       insert: jest.fn().mockResolvedValue(row),
       findAll: jest.fn().mockResolvedValue([row, row]),
@@ -168,6 +178,7 @@ describe("ReservationsService", () => {
       holdsService as any,
       publisher as any,
       partnersClient as any,
+      paymentClient as any,
     );
   });
 
@@ -629,7 +640,7 @@ describe("ReservationsService", () => {
       );
     });
 
-    it("returns mapped response", async () => {
+    it("returns mapped response with null refund for non-confirmed cancellations", async () => {
       const cancelledRow = makeRow({
         status: "cancelled",
         reason: "changed mind",
@@ -641,7 +652,56 @@ describe("ReservationsService", () => {
       const result = await service.cancel("res-uuid", "changed mind");
 
       expect(reservationsRepo.toResponse).toHaveBeenCalledWith(cancelledRow);
-      expect(result).toEqual({ id: cancelledRow.id });
+      expect(result).toEqual({ id: cancelledRow.id, refund: null });
+      expect(paymentClient.requestRefund).not.toHaveBeenCalled();
+    });
+
+    it("triggers automated refund only for prior status=confirmed", async () => {
+      const cancelledRow = makeRow({ status: "cancelled" });
+      reservationsRepo.cancel = jest
+        .fn()
+        .mockResolvedValue({ row: cancelledRow, priorStatus: "confirmed" });
+
+      const result = await service.cancel("res-uuid", "changed mind", "guest", {
+        actorId: "user-7",
+        requestIp: "10.0.0.1",
+      });
+
+      expect(paymentClient.requestRefund).toHaveBeenCalledWith({
+        reservationId: "res-uuid",
+        reason: "changed mind",
+        actorId: "user-7",
+        actorRole: "guest",
+        requestIp: "10.0.0.1",
+      });
+      expect(result.refund).toEqual(
+        expect.objectContaining({ status: "succeeded", refundedUsd: 522 }),
+      );
+    });
+
+    it("does not call paymentClient for prior status=submitted (no captured payment yet)", async () => {
+      const cancelledRow = makeRow({ status: "cancelled" });
+      reservationsRepo.cancel = jest
+        .fn()
+        .mockResolvedValue({ row: cancelledRow, priorStatus: "submitted" });
+
+      await service.cancel("res-uuid", "changed mind");
+
+      expect(paymentClient.requestRefund).not.toHaveBeenCalled();
+    });
+
+    it("swallows payment-service errors so cancellation still succeeds", async () => {
+      const cancelledRow = makeRow({ status: "cancelled" });
+      reservationsRepo.cancel = jest
+        .fn()
+        .mockResolvedValue({ row: cancelledRow, priorStatus: "confirmed" });
+      paymentClient.requestRefund.mockRejectedValue(
+        new Error("payment-service unreachable"),
+      );
+
+      const result = await service.cancel("res-uuid", "changed mind");
+
+      expect(result).toEqual({ id: cancelledRow.id, refund: null });
     });
 
     it("partner actor on confirmed reservation calls repo.cancel and releases inventory", async () => {

--- a/services/booking-service/src/reservations/reservations.service.ts
+++ b/services/booking-service/src/reservations/reservations.service.ts
@@ -13,6 +13,7 @@ import {
 } from "../fare/fare-calculator.service.js";
 import { InventoryClient } from "../clients/inventory.client.js";
 import { PartnersClient } from "../clients/partners.client.js";
+import { PaymentClient, RefundOutcome } from "../clients/payment.client.js";
 import { ReservationsRepository } from "./reservations.repository.js";
 import { HoldsService } from "./holds.service.js";
 import { EventsPublisher } from "../events/events.publisher.js";
@@ -41,6 +42,7 @@ export class ReservationsService {
     private readonly holdsService: HoldsService,
     private readonly publisher: EventsPublisher,
     private readonly partnersClient: PartnersClient,
+    private readonly paymentClient: PaymentClient,
   ) {}
 
   async preview(dto: PreviewReservationDto): Promise<FareBreakdown> {
@@ -377,7 +379,15 @@ export class ReservationsService {
     return this.refundQuote(total, String(row.check_in));
   }
 
-  async cancel(id: string, reason: string, actor: BookingActor = "guest") {
+  async cancel(
+    id: string,
+    reason: string,
+    actor: BookingActor = "guest",
+    audit: { actorId: string | null; requestIp: string | null } = {
+      actorId: null,
+      requestIp: null,
+    },
+  ) {
     if (actor === "partner") {
       const current = await this.reservationsRepo.findById(id);
       if (current.status !== "confirmed") {
@@ -387,9 +397,6 @@ export class ReservationsService {
       }
     }
 
-    // TODO (partner path): trigger refund through payment-service before releasing inventory.
-    // Partner-initiated cancels break the contract on the guest's side, so the
-    // guest should be refunded automatically rather than chase their money.
     const { row, priorStatus } = await this.reservationsRepo.cancel(id, reason);
 
     try {
@@ -413,8 +420,31 @@ export class ReservationsService {
       );
     }
 
+    // Automated refund (issue #27). Only `confirmed` reservations have a
+    // captured payment to refund — `held`/`submitted`/`failed` either never
+    // charged or were already released by the payment retry logic. We treat
+    // the refund as best-effort: the cancellation must persist even if the
+    // gateway is unreachable, and payment-service is responsible for raising
+    // the customer-support alert + writing a failed audit row in that case.
+    let refund: RefundOutcome | null = null;
+    if (priorStatus === "confirmed") {
+      try {
+        refund = await this.paymentClient.requestRefund({
+          reservationId: id,
+          reason,
+          actorId: audit.actorId,
+          actorRole: actor,
+          requestIp: audit.requestIp,
+        });
+      } catch (err) {
+        this.logger.error(
+          `Automated refund request failed for reservation ${id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     this.emit("booking.cancelled", row, actor);
-    return this.reservationsRepo.toResponse(row);
+    return { ...this.reservationsRepo.toResponse(row), refund };
   }
 
   async rehold(id: string) {

--- a/services/booking-service/tsconfig.json
+++ b/services/booking-service/tsconfig.json
@@ -23,7 +23,14 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.spec.json" }]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }

--- a/services/booking-service/tsconfig.json
+++ b/services/booking-service/tsconfig.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist"]
+  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.spec.json" }]
 }

--- a/services/booking-service/tsconfig.spec.json
+++ b/services/booking-service/tsconfig.spec.json
@@ -5,12 +5,19 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolvePackageJsonExports": false,
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     "src/**/*.d.ts",
     "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }

--- a/services/integration-service/eslint.config.mjs
+++ b/services/integration-service/eslint.config.mjs
@@ -19,9 +19,7 @@ export default tseslint.config(
       },
       sourceType: 'commonjs',
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ['kysely.config.ts', 'migrations/*.ts', 'scripts/*.ts'],
-        },
+        project: ["./tsconfig.json", "./tsconfig.spec.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/services/integration-service/tsconfig.json
+++ b/services/integration-service/tsconfig.json
@@ -23,7 +23,14 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.spec.json" }]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }

--- a/services/integration-service/tsconfig.json
+++ b/services/integration-service/tsconfig.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist"]
+  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.spec.json" }]
 }

--- a/services/integration-service/tsconfig.spec.json
+++ b/services/integration-service/tsconfig.spec.json
@@ -5,12 +5,19 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolvePackageJsonExports": false,
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     "src/**/*.d.ts",
     "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }

--- a/services/inventory-service/eslint.config.mjs
+++ b/services/inventory-service/eslint.config.mjs
@@ -19,9 +19,7 @@ export default tseslint.config(
       },
       sourceType: 'commonjs',
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ['kysely.config.ts', 'migrations/*.ts', 'scripts/*.ts'],
-        },
+        project: ["./tsconfig.json", "./tsconfig.spec.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/services/inventory-service/tsconfig.json
+++ b/services/inventory-service/tsconfig.json
@@ -23,7 +23,14 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.spec.json" }]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }

--- a/services/inventory-service/tsconfig.json
+++ b/services/inventory-service/tsconfig.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist"]
+  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.spec.json" }]
 }

--- a/services/inventory-service/tsconfig.spec.json
+++ b/services/inventory-service/tsconfig.spec.json
@@ -5,12 +5,19 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolvePackageJsonExports": false,
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     "src/**/*.d.ts",
     "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }

--- a/services/notification-service/eslint.config.mjs
+++ b/services/notification-service/eslint.config.mjs
@@ -19,7 +19,7 @@ export default tseslint.config(
       },
       sourceType: 'commonjs',
       parserOptions: {
-        projectService: true,
+        project: ["./tsconfig.json", "./tsconfig.spec.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/services/notification-service/tsconfig.json
+++ b/services/notification-service/tsconfig.json
@@ -23,7 +23,14 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.spec.json" }]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }

--- a/services/notification-service/tsconfig.json
+++ b/services/notification-service/tsconfig.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist"]
+  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.spec.json" }]
 }

--- a/services/notification-service/tsconfig.spec.json
+++ b/services/notification-service/tsconfig.spec.json
@@ -5,12 +5,19 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolvePackageJsonExports": false,
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     "src/**/*.d.ts",
     "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }

--- a/services/partners-service/eslint.config.mjs
+++ b/services/partners-service/eslint.config.mjs
@@ -19,9 +19,7 @@ export default tseslint.config(
       },
       sourceType: 'commonjs',
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ['kysely.config.ts', 'migrations/*.ts', 'scripts/*.ts'],
-        },
+        project: ["./tsconfig.json", "./tsconfig.spec.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/services/partners-service/tsconfig.json
+++ b/services/partners-service/tsconfig.json
@@ -23,7 +23,14 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.spec.json" }]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }

--- a/services/partners-service/tsconfig.json
+++ b/services/partners-service/tsconfig.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist"]
+  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.spec.json" }]
 }

--- a/services/partners-service/tsconfig.spec.json
+++ b/services/partners-service/tsconfig.spec.json
@@ -5,12 +5,19 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolvePackageJsonExports": false,
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     "src/**/*.d.ts",
     "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }

--- a/services/payment-service/eslint.config.mjs
+++ b/services/payment-service/eslint.config.mjs
@@ -19,9 +19,7 @@ export default tseslint.config(
       },
       sourceType: 'commonjs',
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ['kysely.config.ts', 'scripts/*.ts'],
-        },
+        project: ["./tsconfig.json", "./tsconfig.spec.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/services/payment-service/src/clients/booking.client.ts
+++ b/services/payment-service/src/clients/booking.client.ts
@@ -13,6 +13,12 @@ export interface ReservationDetails {
   snapshot: { propertyName?: string } | null;
 }
 
+export interface RefundQuote {
+  policy: "full_refund" | "partial_refund" | "no_refund";
+  refundableUsd: number;
+  daysUntilCheckIn: number;
+}
+
 @Injectable()
 export class BookingClient {
   private readonly logger = new Logger(BookingClient.name);
@@ -26,6 +32,21 @@ export class BookingClient {
         throw new UpstreamServiceError("booking-service", `HTTP ${res.status}`);
       }
       return (await res.json()) as ReservationDetails;
+    } catch (err) {
+      if (err instanceof UpstreamServiceError) throw err;
+      throw new UpstreamServiceError("booking-service", err);
+    }
+  }
+
+  async getRefundQuote(reservationId: string): Promise<RefundQuote> {
+    try {
+      const res = await fetch(
+        `${this.baseUrl}/reservations/${reservationId}/refund-quote`,
+      );
+      if (!res.ok) {
+        throw new UpstreamServiceError("booking-service", `HTTP ${res.status}`);
+      }
+      return (await res.json()) as RefundQuote;
     } catch (err) {
       if (err instanceof UpstreamServiceError) throw err;
       throw new UpstreamServiceError("booking-service", err);

--- a/services/payment-service/src/clients/notification.client.spec.ts
+++ b/services/payment-service/src/clients/notification.client.spec.ts
@@ -112,4 +112,130 @@ describe("NotificationClient", () => {
       ).resolves.not.toThrow();
     });
   });
+
+  // ─── sendRefundIssued ──────────────────────────────────────────────────────
+
+  describe("sendRefundIssued", () => {
+    it("emails the guest with the refund amount, comprobante and ETA", async () => {
+      mockFetch.mockReturnValue(okResponse());
+
+      await client.sendRefundIssued({
+        to: "guest@example.com",
+        reservationId: "res-uuid",
+        refundedUsd: 175.25,
+        policy: "partial_refund",
+        refundExternalRef: "re_test_xyz",
+      });
+
+      const body = JSON.parse(
+        (mockFetch.mock.calls[0][1] as RequestInit).body as string,
+      );
+      expect(body.to).toBe("guest@example.com");
+      expect(body.userId).toBe("res-uuid");
+      expect(body.channel).toBe("email");
+      expect(body.message).toContain("175.25");
+      expect(body.message).toContain("re_test_xyz");
+      expect(body.message).toMatch(/d[ií]as h[áa]biles/);
+      expect(body.html).toContain("Reembolso parcial");
+    });
+
+    it("uses the full-refund label when policy is full_refund", async () => {
+      mockFetch.mockReturnValue(okResponse());
+
+      await client.sendRefundIssued({
+        to: "guest@example.com",
+        reservationId: "res-uuid",
+        refundedUsd: 350.5,
+        policy: "full_refund",
+        refundExternalRef: "re_full",
+      });
+
+      const body = JSON.parse(
+        (mockFetch.mock.calls[0][1] as RequestInit).body as string,
+      );
+      expect(body.html).toContain("Reembolso total");
+    });
+
+    it("does not throw when notification-service is unavailable", async () => {
+      mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      await expect(
+        client.sendRefundIssued({
+          to: "guest@example.com",
+          reservationId: "res-uuid",
+          refundedUsd: 100,
+          policy: "full_refund",
+          refundExternalRef: "re_x",
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
+
+  // ─── sendRefundFailedAlert ─────────────────────────────────────────────────
+
+  describe("sendRefundFailedAlert", () => {
+    it("routes to the customer-support inbox with actor metadata", async () => {
+      mockFetch.mockReturnValue(okResponse());
+
+      await client.sendRefundFailedAlert({
+        reservationId: "res-uuid",
+        paymentIntentId: "pi_test_abc",
+        attemptedUsd: 350.5,
+        failureReason: "card_not_refundable",
+        actorId: "user-7",
+        actorRole: "guest",
+      });
+
+      const body = JSON.parse(
+        (mockFetch.mock.calls[0][1] as RequestInit).body as string,
+      );
+      expect(body.userId).toBe("customer-support");
+      expect(body.subject).toContain("ALERTA");
+      expect(body.message).toContain("pi_test_abc");
+      expect(body.message).toContain("card_not_refundable");
+      expect(body.html).toContain("user-7");
+    });
+
+    it("respects CUSTOMER_SUPPORT_EMAIL when configured", async () => {
+      const prev = process.env.CUSTOMER_SUPPORT_EMAIL;
+      process.env.CUSTOMER_SUPPORT_EMAIL = "ops@example.com";
+      const overrideClient = new NotificationClient();
+      mockFetch.mockReturnValue(okResponse());
+
+      await overrideClient.sendRefundFailedAlert({
+        reservationId: "res-uuid",
+        paymentIntentId: "pi_x",
+        attemptedUsd: 10,
+        failureReason: "boom",
+        actorId: null,
+        actorRole: null,
+      });
+
+      const body = JSON.parse(
+        (mockFetch.mock.calls[0][1] as RequestInit).body as string,
+      );
+      expect(body.to).toBe("ops@example.com");
+
+      if (prev !== undefined) {
+        process.env.CUSTOMER_SUPPORT_EMAIL = prev;
+      } else {
+        delete process.env.CUSTOMER_SUPPORT_EMAIL;
+      }
+    });
+
+    it("does not throw when notification-service is unavailable", async () => {
+      mockFetch.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      await expect(
+        client.sendRefundFailedAlert({
+          reservationId: "res-uuid",
+          paymentIntentId: "pi_x",
+          attemptedUsd: 10,
+          failureReason: "boom",
+          actorId: null,
+          actorRole: null,
+        }),
+      ).resolves.not.toThrow();
+    });
+  });
 });

--- a/services/payment-service/src/clients/notification.client.ts
+++ b/services/payment-service/src/clients/notification.client.ts
@@ -1,10 +1,17 @@
 import { Injectable, Logger } from "@nestjs/common";
 
+// ETA shown to the guest after a successful refund. Stripe credits the original
+// payment method in 5-10 business days; we round up to a single span so the
+// email reads cleanly. Update if Stripe or PSP commitments change.
+const REFUND_ETA_LABEL = "5 a 10 días hábiles";
+
 @Injectable()
 export class NotificationClient {
   private readonly logger = new Logger(NotificationClient.name);
   private readonly baseUrl =
     process.env.NOTIFICATION_SERVICE_URL ?? "http://localhost:3006";
+  private readonly customerSupportInbox =
+    process.env.CUSTOMER_SUPPORT_EMAIL ?? "soporte@travelhub.com";
 
   async sendPaymentSucceeded(opts: {
     to: string;
@@ -72,6 +79,101 @@ export class NotificationClient {
       channel: "email",
       subject: "Pago no procesado — TravelHub",
       message: `No pudimos procesar el pago para la reserva ${opts.reservationId}. Motivo: ${opts.reason}`,
+      html,
+    });
+  }
+
+  async sendRefundIssued(opts: {
+    to: string;
+    reservationId: string;
+    refundedUsd: number;
+    policy: "full_refund" | "partial_refund";
+    refundExternalRef: string;
+  }): Promise<void> {
+    const policyLabel =
+      opts.policy === "full_refund"
+        ? "Reembolso total"
+        : "Reembolso parcial según política de cancelación";
+    const html = `
+      <div style="font-family:sans-serif;max-width:520px;margin:auto;padding:32px">
+        <h2 style="color:#1a56db">Tu reembolso fue procesado</h2>
+        <p>${policyLabel}. Acreditaremos el importe en el mismo medio de pago utilizado para la compra.</p>
+        <table style="width:100%;border-collapse:collapse;margin:24px 0">
+          <tr>
+            <td style="padding:8px 0;color:#6b7280;font-size:14px">Número de reserva</td>
+            <td style="padding:8px 0;font-weight:600;font-size:14px">${opts.reservationId}</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 0;color:#6b7280;font-size:14px">Importe reembolsado</td>
+            <td style="padding:8px 0;font-weight:600;font-size:14px">USD $${opts.refundedUsd.toFixed(2)}</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 0;color:#6b7280;font-size:14px">Comprobante</td>
+            <td style="padding:8px 0;font-family:monospace;font-size:13px">${opts.refundExternalRef}</td>
+          </tr>
+          <tr>
+            <td style="padding:8px 0;color:#6b7280;font-size:14px">Tiempo estimado de acreditación</td>
+            <td style="padding:8px 0;font-weight:600;font-size:14px">${REFUND_ETA_LABEL}</td>
+          </tr>
+        </table>
+        <p style="color:#6b7280;font-size:13px">
+          Si el monto no aparece en tu cuenta luego del plazo indicado, responde este correo y te ayudaremos.
+        </p>
+        <p style="color:#6b7280;font-size:13px">— El equipo de TravelHub</p>
+      </div>
+    `;
+    await this.send({
+      userId: opts.reservationId,
+      to: opts.to,
+      channel: "email",
+      subject: "Reembolso procesado — TravelHub",
+      message: `Reembolso de USD $${opts.refundedUsd.toFixed(2)} para la reserva ${opts.reservationId}. Acreditación estimada: ${REFUND_ETA_LABEL}. Comprobante: ${opts.refundExternalRef}.`,
+      html,
+    });
+  }
+
+  async sendRefundFailedAlert(opts: {
+    reservationId: string;
+    paymentIntentId: string;
+    attemptedUsd: number;
+    failureReason: string;
+    actorId: string | null;
+    actorRole: string | null;
+  }): Promise<void> {
+    const html = `
+      <div style="font-family:sans-serif;max-width:560px;margin:auto;padding:32px">
+        <h2 style="color:#dc2626">Acción requerida — reembolso falló</h2>
+        <p>La pasarela de pago rechazó un reembolso automático. Resolución manual requerida.</p>
+        <table style="width:100%;border-collapse:collapse;margin:24px 0;font-size:14px">
+          <tr>
+            <td style="padding:6px 0;color:#6b7280">Reserva</td>
+            <td style="padding:6px 0;font-weight:600">${opts.reservationId}</td>
+          </tr>
+          <tr>
+            <td style="padding:6px 0;color:#6b7280">PaymentIntent</td>
+            <td style="padding:6px 0;font-family:monospace">${opts.paymentIntentId}</td>
+          </tr>
+          <tr>
+            <td style="padding:6px 0;color:#6b7280">Importe intentado</td>
+            <td style="padding:6px 0;font-weight:600">USD $${opts.attemptedUsd.toFixed(2)}</td>
+          </tr>
+          <tr>
+            <td style="padding:6px 0;color:#6b7280">Solicitado por</td>
+            <td style="padding:6px 0">${opts.actorRole ?? "system"} ${opts.actorId ? `(${opts.actorId})` : ""}</td>
+          </tr>
+          <tr>
+            <td style="padding:6px 0;color:#6b7280;vertical-align:top">Motivo del fallo</td>
+            <td style="padding:6px 0">${opts.failureReason}</td>
+          </tr>
+        </table>
+      </div>
+    `;
+    await this.send({
+      userId: "customer-support",
+      to: this.customerSupportInbox,
+      channel: "email",
+      subject: `[ALERTA] Reembolso falló — reserva ${opts.reservationId}`,
+      message: `Stripe rechazó el reembolso de USD $${opts.attemptedUsd.toFixed(2)} para la reserva ${opts.reservationId} (PI ${opts.paymentIntentId}). Motivo: ${opts.failureReason}.`,
       html,
     });
   }

--- a/services/payment-service/src/database/database.types.ts
+++ b/services/payment-service/src/database/database.types.ts
@@ -138,6 +138,11 @@ export interface PaymentAdjustmentsTable {
   applied_at: Generated<Date>;
   external_ref: NullableText;
   reason: NullableText;
+  status: Generated<string>; // succeeded | failed
+  failure_reason: NullableText;
+  actor_id: NullableText;
+  actor_role: NullableText;
+  request_ip: NullableText;
   created_at: Generated<Date>;
 }
 
@@ -203,4 +208,4 @@ export type PaymentAdjustmentRow = Selectable<PaymentAdjustmentsTable>;
 export type NewPaymentAdjustment = Omit<
   Insertable<PaymentAdjustmentsTable>,
   "id" | "applied_at" | "created_at"
-> & { applied_at?: Date | string };
+> & { applied_at?: Date };

--- a/services/payment-service/src/database/migrations/20260510_001_payment_adjustments_refund_audit.ts
+++ b/services/payment-service/src/database/migrations/20260510_001_payment_adjustments_refund_audit.ts
@@ -1,0 +1,39 @@
+import type { Kysely } from "kysely";
+import { sql } from "kysely";
+
+// Audit columns for automated refunds (issue #27).
+//
+// Every refund — successful or failed — produces a payment_adjustments row.
+// The actor and IP must be persisted alongside the Stripe refund id so support
+// can answer "who triggered this and from where" without joining other systems.
+export async function up(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE payment_adjustments
+      ADD COLUMN IF NOT EXISTS status         TEXT NOT NULL DEFAULT 'succeeded',
+      ADD COLUMN IF NOT EXISTS failure_reason TEXT,
+      ADD COLUMN IF NOT EXISTS actor_id       TEXT,
+      ADD COLUMN IF NOT EXISTS actor_role     TEXT,
+      ADD COLUMN IF NOT EXISTS request_ip     TEXT
+  `.execute(db);
+
+  await sql`
+    ALTER TABLE payment_adjustments
+      ADD CONSTRAINT payment_adjustments_status_chk
+      CHECK (status IN ('succeeded', 'failed'))
+  `.execute(db);
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  await sql`
+    ALTER TABLE payment_adjustments
+      DROP CONSTRAINT IF EXISTS payment_adjustments_status_chk
+  `.execute(db);
+  await sql`
+    ALTER TABLE payment_adjustments
+      DROP COLUMN IF EXISTS request_ip,
+      DROP COLUMN IF EXISTS actor_role,
+      DROP COLUMN IF EXISTS actor_id,
+      DROP COLUMN IF EXISTS failure_reason,
+      DROP COLUMN IF EXISTS status
+  `.execute(db);
+}

--- a/services/payment-service/src/payments/dto/issue-refund.dto.ts
+++ b/services/payment-service/src/payments/dto/issue-refund.dto.ts
@@ -1,0 +1,9 @@
+// Body of POST /payments/:reservationId/refund.
+// Actor metadata is supplied by the upstream caller (booking-service forwards
+// the gateway-trusted x-user-id / x-user-role) so it can be persisted on the
+// audit row alongside the IP captured by the controller.
+export class IssueRefundDto {
+  reason: string;
+  actorId?: string | null;
+  actorRole?: string | null;
+}

--- a/services/payment-service/src/payments/payments.module.ts
+++ b/services/payment-service/src/payments/payments.module.ts
@@ -2,12 +2,20 @@ import { Module } from "@nestjs/common";
 import { PaymentsController } from "./payments.controller.js";
 import { PaymentsService } from "./payments.service.js";
 import { PaymentsRepository } from "./payments.repository.js";
+import { RefundsController } from "./refunds.controller.js";
+import { RefundsService } from "./refunds.service.js";
+import { RefundsRepository } from "./refunds.repository.js";
 import { ClientsModule } from "../clients/clients.module.js";
 import { CommissionRulesModule } from "../commission-rules/commission-rules.module.js";
 
 @Module({
   imports: [ClientsModule, CommissionRulesModule],
-  controllers: [PaymentsController],
-  providers: [PaymentsService, PaymentsRepository],
+  controllers: [PaymentsController, RefundsController],
+  providers: [
+    PaymentsService,
+    PaymentsRepository,
+    RefundsService,
+    RefundsRepository,
+  ],
 })
 export class PaymentsModule {}

--- a/services/payment-service/src/payments/refunds.controller.spec.ts
+++ b/services/payment-service/src/payments/refunds.controller.spec.ts
@@ -1,0 +1,37 @@
+import { RefundsController } from "./refunds.controller.js";
+
+describe("RefundsController", () => {
+  it("delegates to RefundsService with the request IP and DTO actor metadata", () => {
+    const service = { issueRefund: jest.fn().mockResolvedValue({}) };
+    const controller = new RefundsController(service as any);
+
+    void controller.issueRefund(
+      "res-uuid",
+      { reason: "guest_cancelled", actorId: "user-7", actorRole: "guest" },
+      "10.0.0.1",
+    );
+
+    expect(service.issueRefund).toHaveBeenCalledWith({
+      reservationId: "res-uuid",
+      reason: "guest_cancelled",
+      actorId: "user-7",
+      actorRole: "guest",
+      requestIp: "10.0.0.1",
+    });
+  });
+
+  it("normalizes missing actor + ip to null so the audit row is well-formed", () => {
+    const service = { issueRefund: jest.fn().mockResolvedValue({}) };
+    const controller = new RefundsController(service as any);
+
+    void controller.issueRefund("res-uuid", { reason: "system" }, "");
+
+    expect(service.issueRefund).toHaveBeenCalledWith({
+      reservationId: "res-uuid",
+      reason: "system",
+      actorId: null,
+      actorRole: null,
+      requestIp: null,
+    });
+  });
+});

--- a/services/payment-service/src/payments/refunds.controller.spec.ts
+++ b/services/payment-service/src/payments/refunds.controller.spec.ts
@@ -1,13 +1,14 @@
 import { RefundsController } from "./refunds.controller.js";
 
 describe("RefundsController", () => {
-  it("delegates to RefundsService with the request IP and DTO actor metadata", () => {
+  it("prefers x-forwarded-for over the direct request IP for audit logging", () => {
     const service = { issueRefund: jest.fn().mockResolvedValue({}) };
     const controller = new RefundsController(service as any);
 
     void controller.issueRefund(
       "res-uuid",
       { reason: "guest_cancelled", actorId: "user-7", actorRole: "guest" },
+      "203.0.113.5",
       "10.0.0.1",
     );
 
@@ -16,15 +17,31 @@ describe("RefundsController", () => {
       reason: "guest_cancelled",
       actorId: "user-7",
       actorRole: "guest",
-      requestIp: "10.0.0.1",
+      requestIp: "203.0.113.5",
     });
+  });
+
+  it("falls back to the direct request IP when x-forwarded-for is absent", () => {
+    const service = { issueRefund: jest.fn().mockResolvedValue({}) };
+    const controller = new RefundsController(service as any);
+
+    void controller.issueRefund(
+      "res-uuid",
+      { reason: "guest_cancelled" },
+      undefined as any,
+      "10.0.0.1",
+    );
+
+    expect(service.issueRefund).toHaveBeenCalledWith(
+      expect.objectContaining({ requestIp: "10.0.0.1" }),
+    );
   });
 
   it("normalizes missing actor + ip to null so the audit row is well-formed", () => {
     const service = { issueRefund: jest.fn().mockResolvedValue({}) };
     const controller = new RefundsController(service as any);
 
-    void controller.issueRefund("res-uuid", { reason: "system" }, "");
+    void controller.issueRefund("res-uuid", { reason: "system" }, "", "");
 
     expect(service.issueRefund).toHaveBeenCalledWith({
       reservationId: "res-uuid",

--- a/services/payment-service/src/payments/refunds.controller.ts
+++ b/services/payment-service/src/payments/refunds.controller.ts
@@ -1,0 +1,32 @@
+import {
+  Body,
+  Controller,
+  HttpCode,
+  HttpStatus,
+  Ip,
+  Param,
+  Post,
+} from "@nestjs/common";
+import { RefundsService } from "./refunds.service.js";
+import { IssueRefundDto } from "./dto/issue-refund.dto.js";
+
+@Controller("payments")
+export class RefundsController {
+  constructor(private readonly refundsService: RefundsService) {}
+
+  @Post(":reservationId/refund")
+  @HttpCode(HttpStatus.OK)
+  issueRefund(
+    @Param("reservationId") reservationId: string,
+    @Body() dto: IssueRefundDto,
+    @Ip() ip: string,
+  ) {
+    return this.refundsService.issueRefund({
+      reservationId,
+      reason: dto.reason,
+      actorId: dto.actorId ?? null,
+      actorRole: dto.actorRole ?? null,
+      requestIp: ip || null,
+    });
+  }
+}

--- a/services/payment-service/src/payments/refunds.controller.ts
+++ b/services/payment-service/src/payments/refunds.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Headers,
   HttpCode,
   HttpStatus,
   Ip,
@@ -9,6 +10,7 @@ import {
 } from "@nestjs/common";
 import { RefundsService } from "./refunds.service.js";
 import { IssueRefundDto } from "./dto/issue-refund.dto.js";
+import { resolveClientIp } from "./resolve-client-ip.js";
 
 @Controller("payments")
 export class RefundsController {
@@ -19,14 +21,15 @@ export class RefundsController {
   issueRefund(
     @Param("reservationId") reservationId: string,
     @Body() dto: IssueRefundDto,
-    @Ip() ip: string,
+    @Headers("x-forwarded-for") forwardedFor: string,
+    @Ip() directIp: string,
   ) {
     return this.refundsService.issueRefund({
       reservationId,
       reason: dto.reason,
       actorId: dto.actorId ?? null,
       actorRole: dto.actorRole ?? null,
-      requestIp: ip || null,
+      requestIp: resolveClientIp(forwardedFor, directIp),
     });
   }
 }

--- a/services/payment-service/src/payments/refunds.repository.spec.ts
+++ b/services/payment-service/src/payments/refunds.repository.spec.ts
@@ -1,0 +1,79 @@
+import { RefundsRepository } from "./refunds.repository.js";
+
+function makeDb(opts: { many?: Record<string, unknown>[] } = {}) {
+  const db: Record<string, jest.Mock> = {};
+  const chain = [
+    "selectFrom",
+    "insertInto",
+    "where",
+    "selectAll",
+    "orderBy",
+    "values",
+    "returningAll",
+  ];
+  chain.forEach((m) => {
+    db[m] = jest.fn().mockReturnValue(db);
+  });
+  db.execute = jest.fn().mockResolvedValue(opts.many ?? []);
+  return db as any;
+}
+
+function makeAdjustment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "adj-uuid",
+    payment_id: "pay-uuid",
+    kind: "refund",
+    amount_usd: "100.00",
+    external_ref: "re_test_xyz",
+    reason: "guest_cancelled",
+    status: "succeeded",
+    failure_reason: null,
+    actor_id: "user-7",
+    actor_role: "guest",
+    request_ip: "10.0.0.1",
+    applied_at: new Date(),
+    created_at: new Date(),
+    ...overrides,
+  };
+}
+
+describe("RefundsRepository", () => {
+  describe("insert", () => {
+    it("inserts into payment_adjustments and returns the row", async () => {
+      const row = makeAdjustment();
+      const db = makeDb({ many: [row] });
+      const repo = new RefundsRepository(db);
+
+      const result = await repo.insert(row as any);
+
+      expect(db.insertInto).toHaveBeenCalledWith("payment_adjustments");
+      expect(db.values).toHaveBeenCalledWith(row);
+      expect(db.returningAll).toHaveBeenCalled();
+      expect(result).toBe(row);
+    });
+  });
+
+  describe("findByPaymentId", () => {
+    it("queries by payment_id ordered by applied_at desc", async () => {
+      const rows = [makeAdjustment(), makeAdjustment({ id: "adj-2" })];
+      const db = makeDb({ many: rows });
+      const repo = new RefundsRepository(db);
+
+      const result = await repo.findByPaymentId("pay-uuid");
+
+      expect(db.selectFrom).toHaveBeenCalledWith("payment_adjustments");
+      expect(db.where).toHaveBeenCalledWith("payment_id", "=", "pay-uuid");
+      expect(db.orderBy).toHaveBeenCalledWith("applied_at", "desc");
+      expect(result).toBe(rows);
+    });
+
+    it("returns an empty list when no adjustments exist", async () => {
+      const db = makeDb({ many: [] });
+      const repo = new RefundsRepository(db);
+
+      const result = await repo.findByPaymentId("missing");
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/services/payment-service/src/payments/refunds.repository.ts
+++ b/services/payment-service/src/payments/refunds.repository.ts
@@ -1,0 +1,31 @@
+import { Inject, Injectable } from "@nestjs/common";
+import { Kysely } from "kysely";
+import {
+  Database,
+  NewPaymentAdjustment,
+  PaymentAdjustmentRow,
+} from "../database/database.types.js";
+import { KYSELY } from "../database/database.provider.js";
+
+@Injectable()
+export class RefundsRepository {
+  constructor(@Inject(KYSELY) private readonly db: Kysely<Database>) {}
+
+  async insert(data: NewPaymentAdjustment): Promise<PaymentAdjustmentRow> {
+    const [row] = await this.db
+      .insertInto("payment_adjustments")
+      .values(data)
+      .returningAll()
+      .execute();
+    return row;
+  }
+
+  async findByPaymentId(paymentId: string): Promise<PaymentAdjustmentRow[]> {
+    return this.db
+      .selectFrom("payment_adjustments")
+      .selectAll()
+      .where("payment_id", "=", paymentId)
+      .orderBy("applied_at", "desc")
+      .execute();
+  }
+}

--- a/services/payment-service/src/payments/refunds.service.spec.ts
+++ b/services/payment-service/src/payments/refunds.service.spec.ts
@@ -1,0 +1,284 @@
+import {
+  BadGatewayException,
+  BadRequestException,
+  NotFoundException,
+} from "@nestjs/common";
+import { RefundsService } from "./refunds.service.js";
+
+// ─── Stripe mock ──────────────────────────────────────────────────────────────
+
+const mockRefundsCreate = jest.fn();
+
+jest.mock("stripe", () => {
+  return jest.fn().mockImplementation(() => ({
+    refunds: { create: mockRefundsCreate },
+    paymentIntents: { create: jest.fn() },
+    webhooks: { constructEvent: jest.fn() },
+  }));
+});
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makePayment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "pay-uuid",
+    reservation_id: "res-uuid",
+    stripe_payment_intent_id: "pi_test_abc",
+    amount_usd: "350.50",
+    currency: "usd",
+    status: "captured",
+    failure_reason: null,
+    guest_email: "guest@example.com",
+    ...overrides,
+  };
+}
+
+function makeQuote(overrides: Record<string, unknown> = {}) {
+  return {
+    policy: "full_refund",
+    refundableUsd: 350.5,
+    daysUntilCheckIn: 14,
+    ...overrides,
+  };
+}
+
+const INPUT = {
+  reservationId: "res-uuid",
+  reason: "guest_cancelled",
+  actorId: "user-7",
+  actorRole: "guest",
+  requestIp: "10.0.0.1",
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe("RefundsService", () => {
+  let service: RefundsService;
+  let payments: { findByReservationId: jest.Mock };
+  let refunds: { insert: jest.Mock };
+  let booking: { getRefundQuote: jest.Mock };
+  let notifications: {
+    sendRefundIssued: jest.Mock;
+    sendRefundFailedAlert: jest.Mock;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    payments = {
+      findByReservationId: jest.fn().mockResolvedValue(makePayment()),
+    };
+    refunds = {
+      insert: jest.fn().mockResolvedValue({ id: "adj-uuid" }),
+    };
+    booking = {
+      getRefundQuote: jest.fn().mockResolvedValue(makeQuote()),
+    };
+    notifications = {
+      sendRefundIssued: jest.fn().mockResolvedValue(undefined),
+      sendRefundFailedAlert: jest.fn().mockResolvedValue(undefined),
+    };
+    service = new RefundsService(
+      payments as any,
+      refunds as any,
+      booking as any,
+      notifications as any,
+    );
+  });
+
+  it("throws NotFoundException when no payment exists for the reservation", async () => {
+    payments.findByReservationId.mockResolvedValue(undefined);
+
+    await expect(service.issueRefund(INPUT)).rejects.toThrow(NotFoundException);
+    expect(mockRefundsCreate).not.toHaveBeenCalled();
+  });
+
+  it("throws BadRequestException when the payment is not captured", async () => {
+    payments.findByReservationId.mockResolvedValue(
+      makePayment({ status: "pending" }),
+    );
+
+    await expect(service.issueRefund(INPUT)).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(mockRefundsCreate).not.toHaveBeenCalled();
+  });
+
+  it("records a zero-amount audit row and skips Stripe when policy is no_refund", async () => {
+    booking.getRefundQuote.mockResolvedValue(
+      makeQuote({ policy: "no_refund", refundableUsd: 0 }),
+    );
+
+    const result = await service.issueRefund(INPUT);
+
+    expect(result).toEqual({
+      status: "skipped",
+      policy: "no_refund",
+      refundedUsd: 0,
+      externalRef: null,
+      adjustmentId: "adj-uuid",
+    });
+    expect(mockRefundsCreate).not.toHaveBeenCalled();
+    expect(refunds.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "refund",
+        amount_usd: 0,
+        status: "succeeded",
+        external_ref: null,
+        actor_id: "user-7",
+        actor_role: "guest",
+        request_ip: "10.0.0.1",
+      }),
+    );
+    expect(notifications.sendRefundIssued).not.toHaveBeenCalled();
+  });
+
+  it("calls Stripe with the original PaymentIntent and amount in cents", async () => {
+    mockRefundsCreate.mockResolvedValue({ id: "re_test_xyz" });
+
+    await service.issueRefund(INPUT);
+
+    expect(mockRefundsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_intent: "pi_test_abc",
+        amount: 35050,
+        reason: "requested_by_customer",
+      }),
+    );
+  });
+
+  it("persists a successful refund audit row with the Stripe refund id", async () => {
+    mockRefundsCreate.mockResolvedValue({ id: "re_test_xyz" });
+
+    await service.issueRefund(INPUT);
+
+    expect(refunds.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "refund",
+        amount_usd: 350.5,
+        external_ref: "re_test_xyz",
+        status: "succeeded",
+        actor_id: "user-7",
+        actor_role: "guest",
+        request_ip: "10.0.0.1",
+      }),
+    );
+  });
+
+  it("emails the guest with the refund receipt", async () => {
+    mockRefundsCreate.mockResolvedValue({ id: "re_test_xyz" });
+
+    await service.issueRefund(INPUT);
+
+    expect(notifications.sendRefundIssued).toHaveBeenCalledWith({
+      to: "guest@example.com",
+      reservationId: "res-uuid",
+      refundedUsd: 350.5,
+      policy: "full_refund",
+      refundExternalRef: "re_test_xyz",
+    });
+  });
+
+  it("returns a structured success result", async () => {
+    mockRefundsCreate.mockResolvedValue({ id: "re_test_xyz" });
+
+    const result = await service.issueRefund(INPUT);
+
+    expect(result).toEqual({
+      status: "succeeded",
+      policy: "full_refund",
+      refundedUsd: 350.5,
+      externalRef: "re_test_xyz",
+      adjustmentId: "adj-uuid",
+    });
+  });
+
+  it("alerts customer support and writes a failed audit row when Stripe rejects", async () => {
+    mockRefundsCreate.mockRejectedValue(new Error("card_not_refundable"));
+
+    await expect(service.issueRefund(INPUT)).rejects.toThrow(
+      BadGatewayException,
+    );
+
+    expect(refunds.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        failure_reason: "card_not_refundable",
+        external_ref: null,
+      }),
+    );
+    expect(notifications.sendRefundFailedAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reservationId: "res-uuid",
+        paymentIntentId: "pi_test_abc",
+        attemptedUsd: 350.5,
+        failureReason: "card_not_refundable",
+        actorId: "user-7",
+        actorRole: "guest",
+      }),
+    );
+    expect(notifications.sendRefundIssued).not.toHaveBeenCalled();
+  });
+
+  it("does not throw if alerting customer support fails", async () => {
+    mockRefundsCreate.mockRejectedValue(new Error("gateway_down"));
+    notifications.sendRefundFailedAlert.mockRejectedValue(
+      new Error("smtp_down"),
+    );
+
+    await expect(service.issueRefund(INPUT)).rejects.toThrow(
+      BadGatewayException,
+    );
+  });
+
+  it("does not throw if the guest receipt email fails", async () => {
+    mockRefundsCreate.mockResolvedValue({ id: "re_test_xyz" });
+    notifications.sendRefundIssued.mockRejectedValue(new Error("smtp_down"));
+
+    await expect(service.issueRefund(INPUT)).resolves.toMatchObject({
+      status: "succeeded",
+    });
+  });
+
+  it("verifies the cancellation policy from booking-service before refunding", async () => {
+    mockRefundsCreate.mockResolvedValue({ id: "re_test_xyz" });
+
+    await service.issueRefund(INPUT);
+
+    expect(booking.getRefundQuote).toHaveBeenCalledWith("res-uuid");
+  });
+
+  it("uses the partial refund amount returned by the policy", async () => {
+    booking.getRefundQuote.mockResolvedValue(
+      makeQuote({ policy: "partial_refund", refundableUsd: 175.25 }),
+    );
+    mockRefundsCreate.mockResolvedValue({ id: "re_test_xyz" });
+
+    const result = await service.issueRefund(INPUT);
+
+    expect(mockRefundsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: 17525 }),
+    );
+    expect(result.refundedUsd).toBe(175.25);
+    expect(result.policy).toBe("partial_refund");
+  });
+
+  it("forwards anonymized actor metadata to Stripe so refunds remain traceable", async () => {
+    mockRefundsCreate.mockResolvedValue({ id: "re_test_xyz" });
+
+    await service.issueRefund({
+      ...INPUT,
+      actorId: null,
+      actorRole: null,
+    });
+
+    expect(mockRefundsCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: {
+          reservation_id: "res-uuid",
+          actor_id: "",
+          actor_role: "",
+        },
+      }),
+    );
+  });
+});

--- a/services/payment-service/src/payments/refunds.service.spec.ts
+++ b/services/payment-service/src/payments/refunds.service.spec.ts
@@ -262,6 +262,64 @@ describe("RefundsService", () => {
     expect(result.policy).toBe("partial_refund");
   });
 
+  it("treats stripe status='pending' as a successful in-flight refund", async () => {
+    mockRefundsCreate.mockResolvedValue({ id: "re_async", status: "pending" });
+
+    const result = await service.issueRefund(INPUT);
+
+    expect(result.status).toBe("succeeded");
+    expect(refunds.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "succeeded",
+        external_ref: "re_async",
+      }),
+    );
+    expect(notifications.sendRefundIssued).toHaveBeenCalled();
+    expect(notifications.sendRefundFailedAlert).not.toHaveBeenCalled();
+  });
+
+  it("treats stripe status='failed' as a gateway rejection and alerts support", async () => {
+    mockRefundsCreate.mockResolvedValue({
+      id: "re_dead",
+      status: "failed",
+      failure_reason: "lost_or_stolen_card",
+    });
+
+    await expect(service.issueRefund(INPUT)).rejects.toThrow(
+      BadGatewayException,
+    );
+
+    expect(refunds.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        failure_reason: "lost_or_stolen_card",
+        external_ref: "re_dead",
+      }),
+    );
+    expect(notifications.sendRefundFailedAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ failureReason: "lost_or_stolen_card" }),
+    );
+    expect(notifications.sendRefundIssued).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a synthetic failure reason when stripe omits failure_reason", async () => {
+    mockRefundsCreate.mockResolvedValue({
+      id: "re_canceled",
+      status: "canceled",
+    });
+
+    await expect(service.issueRefund(INPUT)).rejects.toThrow(
+      BadGatewayException,
+    );
+
+    expect(refunds.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "failed",
+        failure_reason: "stripe_status=canceled",
+      }),
+    );
+  });
+
   it("forwards anonymized actor metadata to Stripe so refunds remain traceable", async () => {
     mockRefundsCreate.mockResolvedValue({ id: "re_test_xyz" });
 

--- a/services/payment-service/src/payments/refunds.service.ts
+++ b/services/payment-service/src/payments/refunds.service.ts
@@ -1,0 +1,193 @@
+import {
+  BadGatewayException,
+  BadRequestException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from "@nestjs/common";
+import Stripe from "stripe";
+import { PaymentsRepository } from "./payments.repository.js";
+import { RefundsRepository } from "./refunds.repository.js";
+import { BookingClient, RefundQuote } from "../clients/booking.client.js";
+import { NotificationClient } from "../clients/notification.client.js";
+
+// Subset of the Stripe Refund object we actually use. Avoids namespace
+// access issues under nodenext module resolution (see PaymentsService).
+interface StripeRefund {
+  id: string;
+  status?: string | null;
+}
+
+export interface IssueRefundInput {
+  reservationId: string;
+  reason: string;
+  actorId: string | null;
+  actorRole: string | null;
+  requestIp: string | null;
+}
+
+export interface IssueRefundResult {
+  status: "succeeded" | "skipped";
+  policy: RefundQuote["policy"];
+  refundedUsd: number;
+  externalRef: string | null;
+  adjustmentId: string;
+}
+
+@Injectable()
+export class RefundsService {
+  private readonly logger = new Logger(RefundsService.name);
+  private readonly stripe: InstanceType<typeof Stripe>;
+
+  constructor(
+    private readonly payments: PaymentsRepository,
+    private readonly refunds: RefundsRepository,
+    private readonly booking: BookingClient,
+    private readonly notifications: NotificationClient,
+  ) {
+    const secretKey = process.env.STRIPE_SECRET_KEY ?? "";
+    this.stripe = new Stripe(secretKey);
+  }
+
+  /**
+   * Issues an automated refund for a cancelled reservation.
+   *
+   * Flow:
+   *   1. Find the captured payment for the reservation.
+   *   2. Re-fetch the cancellation policy from booking-service so the policy
+   *      decision is server-authoritative (the caller's quote is advisory).
+   *   3. If policy says no_refund → record a zero-amount audit row and return.
+   *   4. Otherwise call Stripe `refunds.create` against the original PI; on
+   *      failure, record the failed adjustment and alert customer support.
+   *   5. Send the guest the refund receipt with bank ETA.
+   */
+  async issueRefund(input: IssueRefundInput): Promise<IssueRefundResult> {
+    const payment = await this.payments.findByReservationId(
+      input.reservationId,
+    );
+    if (!payment) {
+      throw new NotFoundException(
+        `No payment found for reservation ${input.reservationId}`,
+      );
+    }
+    if (payment.status !== "captured") {
+      throw new BadRequestException(
+        `Refund requires a captured payment (current status: ${payment.status})`,
+      );
+    }
+
+    const quote = await this.booking.getRefundQuote(input.reservationId);
+
+    if (quote.policy === "no_refund" || quote.refundableUsd <= 0) {
+      const adjustment = await this.refunds.insert({
+        payment_id: payment.id,
+        kind: "refund",
+        amount_usd: 0,
+        external_ref: null,
+        reason: input.reason,
+        status: "succeeded",
+        failure_reason: null,
+        actor_id: input.actorId,
+        actor_role: input.actorRole,
+        request_ip: input.requestIp,
+      });
+      this.logger.log(
+        `Refund skipped (policy=no_refund) for reservation ${input.reservationId}`,
+      );
+      return {
+        status: "skipped",
+        policy: "no_refund",
+        refundedUsd: 0,
+        externalRef: null,
+        adjustmentId: adjustment.id,
+      };
+    }
+
+    const amountCents = Math.round(quote.refundableUsd * 100);
+
+    let stripeRefund: StripeRefund;
+    try {
+      stripeRefund = (await this.stripe.refunds.create({
+        payment_intent: payment.stripe_payment_intent_id,
+        amount: amountCents,
+        reason: "requested_by_customer",
+        metadata: {
+          reservation_id: input.reservationId,
+          actor_id: input.actorId ?? "",
+          actor_role: input.actorRole ?? "",
+        },
+      })) as StripeRefund;
+    } catch (err) {
+      const failureReason = err instanceof Error ? err.message : String(err);
+      const adjustment = await this.refunds.insert({
+        payment_id: payment.id,
+        kind: "refund",
+        amount_usd: quote.refundableUsd,
+        external_ref: null,
+        reason: input.reason,
+        status: "failed",
+        failure_reason: failureReason,
+        actor_id: input.actorId,
+        actor_role: input.actorRole,
+        request_ip: input.requestIp,
+      });
+      this.logger.error(
+        `Stripe refund failed for reservation ${input.reservationId}: ${failureReason}`,
+      );
+      await this.notifications
+        .sendRefundFailedAlert({
+          reservationId: input.reservationId,
+          paymentIntentId: payment.stripe_payment_intent_id,
+          attemptedUsd: quote.refundableUsd,
+          failureReason,
+          actorId: input.actorId,
+          actorRole: input.actorRole,
+        })
+        .catch((alertErr) =>
+          this.logger.error(
+            `Failed to alert customer-support inbox: ${alertErr}`,
+          ),
+        );
+      throw new BadGatewayException(
+        `Refund could not be processed (adjustment ${adjustment.id}). Customer support has been notified.`,
+      );
+    }
+
+    const adjustment = await this.refunds.insert({
+      payment_id: payment.id,
+      kind: "refund",
+      amount_usd: quote.refundableUsd,
+      external_ref: stripeRefund.id,
+      reason: input.reason,
+      status: "succeeded",
+      failure_reason: null,
+      actor_id: input.actorId,
+      actor_role: input.actorRole,
+      request_ip: input.requestIp,
+    });
+
+    await this.notifications
+      .sendRefundIssued({
+        to: payment.guest_email,
+        reservationId: input.reservationId,
+        refundedUsd: quote.refundableUsd,
+        policy: quote.policy,
+        refundExternalRef: stripeRefund.id,
+      })
+      .catch((err) =>
+        this.logger.error(`Failed to send refund receipt email: ${err}`),
+      );
+
+    this.logger.log(
+      `Refund ${stripeRefund.id} issued for reservation ${input.reservationId} (USD ${quote.refundableUsd.toFixed(2)})`,
+    );
+
+    return {
+      status: "succeeded",
+      policy: quote.policy,
+      refundedUsd: quote.refundableUsd,
+      externalRef: stripeRefund.id,
+      adjustmentId: adjustment.id,
+    };
+  }
+}

--- a/services/payment-service/src/payments/refunds.service.ts
+++ b/services/payment-service/src/payments/refunds.service.ts
@@ -16,7 +16,16 @@ import { NotificationClient } from "../clients/notification.client.js";
 interface StripeRefund {
   id: string;
   status?: string | null;
+  failure_reason?: string | null;
 }
+
+// Stripe refund states that count as a customer-visible "issued" outcome.
+// `succeeded` settles immediately on most card networks; `pending` is the
+// async path (ACH, certain currencies) — the money is in flight and the bank
+// ETA already covers it, so we audit and email the guest the same way.
+// Anything else (`failed`, `canceled`, `requires_action`) is treated as a
+// gateway rejection: failed audit row + customer-support alert.
+const ISSUED_STRIPE_STATUSES = new Set(["succeeded", "pending"]);
 
 export interface IssueRefundInput {
   reservationId: string;
@@ -153,6 +162,48 @@ export class RefundsService {
       );
     }
 
+    // Stripe accepted the refund call but the resulting state is what tells
+    // us whether to treat this as customer-visible success. `failed`,
+    // `canceled` and `requires_action` all mean the money will not move on
+    // its own, so we audit them as failed and alert customer support.
+    const stripeStatus = stripeRefund.status ?? "succeeded";
+    if (!ISSUED_STRIPE_STATUSES.has(stripeStatus)) {
+      const failureReason =
+        stripeRefund.failure_reason ?? `stripe_status=${stripeStatus}`;
+      const adjustment = await this.refunds.insert({
+        payment_id: payment.id,
+        kind: "refund",
+        amount_usd: quote.refundableUsd,
+        external_ref: stripeRefund.id,
+        reason: input.reason,
+        status: "failed",
+        failure_reason: failureReason,
+        actor_id: input.actorId,
+        actor_role: input.actorRole,
+        request_ip: input.requestIp,
+      });
+      this.logger.error(
+        `Stripe refund ${stripeRefund.id} returned non-issued status "${stripeStatus}" for reservation ${input.reservationId}`,
+      );
+      await this.notifications
+        .sendRefundFailedAlert({
+          reservationId: input.reservationId,
+          paymentIntentId: payment.stripe_payment_intent_id,
+          attemptedUsd: quote.refundableUsd,
+          failureReason,
+          actorId: input.actorId,
+          actorRole: input.actorRole,
+        })
+        .catch((alertErr) =>
+          this.logger.error(
+            `Failed to alert customer-support inbox: ${alertErr}`,
+          ),
+        );
+      throw new BadGatewayException(
+        `Refund could not be processed (adjustment ${adjustment.id}). Customer support has been notified.`,
+      );
+    }
+
     const adjustment = await this.refunds.insert({
       payment_id: payment.id,
       kind: "refund",
@@ -179,7 +230,7 @@ export class RefundsService {
       );
 
     this.logger.log(
-      `Refund ${stripeRefund.id} issued for reservation ${input.reservationId} (USD ${quote.refundableUsd.toFixed(2)})`,
+      `Refund ${stripeRefund.id} issued (stripe_status=${stripeStatus}) for reservation ${input.reservationId} (USD ${quote.refundableUsd.toFixed(2)})`,
     );
 
     return {

--- a/services/payment-service/src/payments/resolve-client-ip.ts
+++ b/services/payment-service/src/payments/resolve-client-ip.ts
@@ -1,0 +1,18 @@
+// Returns the original client IP for audit logging.
+//
+// `@Ip()` (Express `req.ip`) only reflects `x-forwarded-for` when the app has
+// `trust proxy` configured — which it doesn't, since the api-gateway is not
+// the only entry point and we don't want to trust arbitrary proxy headers
+// blindly. Booking-service explicitly forwards the caller's IP via
+// `x-forwarded-for` when invoking our refund endpoint, so we read it here
+// and fall back to `req.ip` when no header is present.
+//
+// The header can be a comma-separated chain (`client, proxy1, proxy2`); the
+// left-most entry is the original client.
+export function resolveClientIp(
+  forwardedFor: string | undefined,
+  directIp: string | undefined,
+): string | null {
+  const fromHeader = forwardedFor?.split(",")[0]?.trim();
+  return fromHeader || directIp || null;
+}

--- a/services/payment-service/tsconfig.json
+++ b/services/payment-service/tsconfig.json
@@ -23,7 +23,14 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.spec.json" }]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }

--- a/services/payment-service/tsconfig.json
+++ b/services/payment-service/tsconfig.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist"]
+  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.spec.json" }]
 }

--- a/services/payment-service/tsconfig.spec.json
+++ b/services/payment-service/tsconfig.spec.json
@@ -5,12 +5,19 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolvePackageJsonExports": false,
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     "src/**/*.d.ts",
     "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }

--- a/services/search-service/eslint.config.mjs
+++ b/services/search-service/eslint.config.mjs
@@ -19,9 +19,7 @@ export default tseslint.config(
       },
       sourceType: 'commonjs',
       parserOptions: {
-        projectService: {
-          allowDefaultProject: ['kysely.config.ts', 'migrations/*.ts', 'scripts/*.ts'],
-        },
+        project: ["./tsconfig.json", "./tsconfig.spec.json"],
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/services/search-service/tsconfig.json
+++ b/services/search-service/tsconfig.json
@@ -23,7 +23,14 @@
     "strictBindCallApply": false,
     "noFallthroughCasesInSwitch": false
   },
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
-  "references": [{ "path": "./tsconfig.spec.json" }]
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "src/**/*.spec.ts",
+    "src/**/*.test.ts"
+  ]
 }

--- a/services/search-service/tsconfig.json
+++ b/services/search-service/tsconfig.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": false
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "test", "dist"]
+  "exclude": ["node_modules", "test", "dist", "src/**/*.spec.ts", "src/**/*.test.ts"],
+  "references": [{ "path": "./tsconfig.spec.json" }]
 }

--- a/services/search-service/tsconfig.spec.json
+++ b/services/search-service/tsconfig.spec.json
@@ -5,12 +5,19 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "resolvePackageJsonExports": false,
-    "types": ["jest", "node"]
+    "types": [
+      "jest",
+      "node"
+    ]
   },
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.test.ts",
     "src/**/*.d.ts",
     "test/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
   ]
 }


### PR DESCRIPTION
## Descripción
<!-- Qué cambia y por qué -->

## Tipo de cambio
- [x] Nueva funcionalidad
- [ ] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [ ] Infraestructura / configuración

## Cómo probar

# Prueba del flujo de Reembolsos Automatizados (#27)

## Setup previo (1 vez)

1. Entra a la app desplegada y crea/usa una cuenta de huésped.
2. Ten a mano una **tarjeta de prueba Stripe**: `4242 4242 4242 4242` · cualquier CVC · fecha futura.

## Caso A — Reembolso total (política ≥7 días antes del check-in)

1. Busca un hotel y reserva con **check-in dentro de 8+ días**.
2. En checkout completa el pago con la tarjeta de prueba.
3. Espera unos segundos a que Stripe confirme (la reserva pasa a `confirmed`).
4. Ve a **Mis viajes** (`/trips`).
5. Click **Cancelar** en la reserva.
6. ✅ El dialog muestra: *"Recibirás un reembolso total de USD $X"*.
7. Click **Sí, cancelar**.
8. ✅ Aparece el dialog **"Reembolso en proceso"** con:
   - Importe a acreditar
   - Comprobante (ID Stripe `re_xxx`)
   - ETA "5 a 10 días hábiles"
9. ✅ Revisa tu correo: llega el email *"Reembolso procesado — TravelHub"* con el comprobante.

## Caso B — Reembolso parcial (2-6 días)

Repite con check-in en **3 días**. En el paso 6 el texto debe decir *"reembolso parcial"* y el monto debe ser **50%** del total.

## Caso C — Sin reembolso (<2 días)

Repite con check-in **mañana**. En el paso 6 el texto debe decir *"no genera reembolso"*. Tras confirmar, aparece **"Reserva cancelada sin reembolso"** y NO llega correo de comprobante.

## Validación de auditoría (opcional, requiere acceso DB)

Después de cualquier reembolso, en `payment_service.payment_adjustments` debe existir una fila con: `kind='refund'`, `status='succeeded'`, `external_ref='re_...'`, `actor_id`, `actor_role='guest'`, `request_ip` y `applied_at`.

---

**Notas:**

- En modo test de Stripe los reembolsos vuelven `succeeded` instantáneamente (no `pending`).
- El path de fallo de gateway (alerta a Servicio al Cliente) no se puede probar fácilmente en producción — requiere forzar un error en Stripe.
- Si no llega el correo, revisa carpeta de spam y que `SMTP_*` esté configurado en el deploy.


## Issues relacionados
<!-- Closes #X  /  Parte de #X  /  N/A -->

## Checklist
- [x] El código compila sin errores
- [x] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [x] El linter no reporta errores (`pnpm run lint`)
