### PR TITLE
feat(booking): estado terminal no_show y reservas pasadas visibles en /trips

### DIFF
--- a/.claude/commands/db.md
+++ b/.claude/commands/db.md
@@ -9,6 +9,7 @@ Each service with a database has `migrate` and `seed` nx targets. The local DB p
 | `inventory-service` | 5434 | `travelhub` |
 | `integration-service` | 5435 | `integration_service` |
 | `booking-service` | 5436 | `travelhub` |
+| `payment-service` | 5437 | `travelhub` |
 | `partners-service` | 5438 | `partners_service` |
 
 ```bash
@@ -31,6 +32,10 @@ pnpm exec nx run integration-service:seed
 # Booking service
 DATABASE_URL=postgres://postgres:postgres@localhost:5436/travelhub pnpm exec nx run booking-service:migrate
 DATABASE_URL=postgres://postgres:postgres@localhost:5436/travelhub pnpm exec nx run booking-service:seed
+
+# Payment service
+DATABASE_URL=postgres://postgres:postgres@localhost:5437/travelhub pnpm exec nx run payment-service:migrate
+DATABASE_URL=postgres://postgres:postgres@localhost:5437/travelhub pnpm exec nx run payment-service:seed
 
 # Partners service
 DATABASE_URL=postgres://postgres:postgres@localhost:5438/partners_service pnpm exec nx run partners-service:migrate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,8 +184,8 @@ Reservations go through the following states:
 ```
 [User clicks Book]
         ↓
-     held  ──(15 min expires)──→  expired
-        │   ──(user cancel)────→  cancelled
+     held  ──(15 min expires)──→  expired                       (terminal)
+        │   ──(user cancel)────→  cancelled                     (terminal)
         │
   [payment-service.initiate() called]
         ↓
@@ -194,8 +194,11 @@ Reservations go through the following states:
         │                                                              │
   [Stripe webhook: payment_intent.succeeded]                [user retries payment]
         ↓                                                              │
-  confirmed  ──(user cancel)──→  cancelled                            ↓
-                                                          failed ──(rehold)──→ held (retry)
+  confirmed  ──(user cancel)────────→  cancelled                       ↓
+        │    ──(no-show job, hourly)─→  no_show     (terminal) failed ──(rehold)──→ held (retry)
+        │    ──(guest check-in)──────→  checked_in
+                                            │
+                                            └──(checkout)──→  checked_out  (terminal)
 ```
 
 | Status | Meaning | Inventory hold | Can re-book same room? |
@@ -203,9 +206,12 @@ Reservations go through the following states:
 | `held` | User is in checkout, room locked | Active (15-min TTL) | No |
 | `submitted` | Payment submitted to Stripe, awaiting webhook | Consumed | Yes |
 | `confirmed` | Webhook fired, booking finalized | Confirmed | No |
-| `expired` | Hold timed out without payment submission | Released | Yes |
+| `checked_in` | Guest has arrived and checked in | Consumed | No |
+| `checked_out` | Guest stayed and checked out (terminal — happy path) | Consumed | No |
+| `no_show` | Guest never arrived past check-in date (terminal — billable) | Consumed | No |
+| `expired` | Hold timed out without payment submission (terminal) | Released | Yes |
 | `failed` | Stripe reported payment failure | Released | Yes |
-| `cancelled` | User cancelled (any non-terminal state) | Released | Yes |
+| `cancelled` | User cancelled (any non-terminal state) (terminal) | Released | Yes |
 
 ### Key transitions
 
@@ -218,7 +224,10 @@ Reservations go through the following states:
 | Stripe webhook `payment_intent.payment_failed` | `submitted` → `failed` | payment-service calls `PATCH /reservations/:id/fail` |
 | `PATCH /reservations/:id/cancel` | any non-terminal → `cancelled` | Frontend/user |
 | `PATCH /reservations/:id/partner-cancel` | `confirmed` → `cancelled` | Partner dashboard (hotel-initiated) |
+| `PATCH /reservations/:id/checkin` | `confirmed` → `checked_in` | Guest (key) or partner |
+| `PATCH /reservations/:id/checkout` | `checked_in` → `checked_out` | Partner dashboard |
 | Hold expiry job (runs every 60s) | `held` → `expired` | booking-service `HoldExpiryService` |
+| No-show job (runs hourly) | `confirmed` (with `check_in < today`) → `no_show` | booking-service `NoShowService` |
 
 ### Important notes
 - The partial unique index on reservations only covers `held` rows — a `submitted` reservation does **not** block a new hold for the same room/dates.
@@ -227,6 +236,7 @@ Reservations go through the following states:
 - On payment retry, `initiate()` detects an existing payment row (`isRetry = true`), calls `rehold` to re-acquire inventory, then proceeds with a new Stripe PaymentIntent and a new payment row.
 - In local dev without Stripe webhooks configured, reservations stay `submitted` after payment. Use the Stripe CLI (`stripe listen --forward-to localhost:3005/payments/webhook`) to test the full flow.
 - `partner-cancel` only accepts `confirmed` reservations. `submitted` is blocked because cancelling mid-payment races the Stripe webhook with no refund wired; `checked_in` is blocked because that case should become a separate early-checkout operation. Refunds for partner-initiated cancels on `confirmed` reservations are not yet implemented (TODO in `reservations.service.ts`).
+- `NoShowService` runs hourly and flips `confirmed` reservations whose `check_in` date has already passed to `no_show`. It does **not** call `inventoryClient.unhold` — no-show is treated as billable revenue (room stays consumed for the stay window), consistent with PMS industry convention.
 
 ## Event Bus (Pub/Sub in GCP, RabbitMQ locally)
 
@@ -308,6 +318,7 @@ booking-service publishes a domain event on every customer-visible status transi
 | `booking.checked_out` | `booking-checked_out` | `notification-booking-checked_out` | yes ("Check-out completado") |
 | `booking.failed` | `booking-failed` | `notification-booking-failed` | no |
 | `booking.expired` | `booking-expired` | `notification-booking-expired` | no |
+| `booking.no_show` | `booking-no_show` | `notification-booking-no_show` | no |
 
 Event payload (kept in sync between `services/booking-service/src/events/events.types.ts` and `services/notification-service/src/events/types.ts`):
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -289,9 +289,12 @@
       "held": "On hold · Complete payment",
       "submitted": "Pending",
       "confirmed": "Confirmed",
+      "checked_in": "Checked in",
+      "checked_out": "Checked out",
       "failed": "Failed",
       "expired": "Expired",
-      "cancelled": "Cancelled"
+      "cancelled": "Cancelled",
+      "no_show": "No show"
     },
     "card": {
       "reservation_id": "Reservation",
@@ -454,7 +457,8 @@
         "checked_out": "Checked out",
         "cancelled": "Cancelled",
         "failed": "Failed",
-        "expired": "Expired"
+        "expired": "Expired",
+        "no_show": "No show"
       },
       "no_reservations": "No reservations for this month.",
       "no_results_filter": "No reservations match the current filters.",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -289,9 +289,12 @@
       "held": "En espera · Completar pago",
       "submitted": "Pendiente",
       "confirmed": "Confirmada",
+      "checked_in": "En hotel",
+      "checked_out": "Check-out completado",
       "failed": "Fallida",
       "expired": "Expirada",
-      "cancelled": "Cancelada"
+      "cancelled": "Cancelada",
+      "no_show": "No presentación"
     },
     "card": {
       "reservation_id": "Reserva",
@@ -454,7 +457,8 @@
         "checked_out": "Check-out",
         "cancelled": "Cancelada",
         "failed": "Fallida",
-        "expired": "Expirada"
+        "expired": "Expirada",
+        "no_show": "No presentación"
       },
       "no_reservations": "No hay reservaciones para este mes.",
       "no_results_filter": "No hay reservaciones que coincidan con los filtros.",

--- a/frontend/src/pages/trips/index.spec.tsx
+++ b/frontend/src/pages/trips/index.spec.tsx
@@ -269,15 +269,35 @@ describe('TripsPage', () => {
       expect(await screen.findByText(es.trips.status.failed)).toBeInTheDocument();
     });
 
-    it('does not render expired reservations', async () => {
+    it('renders expired reservations under past', async () => {
       useAuth.mockReturnValue({ token: TOKEN, user: USER });
       (global.fetch as jest.Mock).mockResolvedValue({
         ok: true,
         json: () => Promise.resolve({ reservations: [makeReservation('expired')] }),
       });
       renderPage();
-      expect(await screen.findByText(es.trips.empty)).toBeInTheDocument();
-      expect(screen.queryByText(es.trips.status.expired)).not.toBeInTheDocument();
+      expect(await screen.findByText(es.trips.status.expired)).toBeInTheDocument();
+      expect(screen.queryByText(es.trips.empty)).not.toBeInTheDocument();
+    });
+
+    it('renders checked_out reservations under past', async () => {
+      useAuth.mockReturnValue({ token: TOKEN, user: USER });
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ reservations: [makeReservation('checked_out')] }),
+      });
+      renderPage();
+      expect(await screen.findByText(es.trips.status.checked_out)).toBeInTheDocument();
+    });
+
+    it('renders no_show reservations under past', async () => {
+      useAuth.mockReturnValue({ token: TOKEN, user: USER });
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ reservations: [makeReservation('no_show')] }),
+      });
+      renderPage();
+      expect(await screen.findByText(es.trips.status.no_show)).toBeInTheDocument();
     });
 
     it('does not show cancel button for failed reservations', async () => {

--- a/frontend/src/pages/trips/index.tsx
+++ b/frontend/src/pages/trips/index.tsx
@@ -35,16 +35,19 @@ import 'dayjs/locale/es';
 
 dayjs.locale('es');
 
-const ACTIVE_STATUSES: ReservationStatus[] = ['held', 'submitted', 'confirmed'];
-const PAST_STATUSES: ReservationStatus[] = ['cancelled', 'failed'];
+const ACTIVE_STATUSES: ReservationStatus[] = ['held', 'submitted', 'confirmed', 'checked_in'];
+const PAST_STATUSES: ReservationStatus[] = ['checked_out', 'no_show', 'cancelled', 'failed', 'expired'];
 
 const STATUS_PILL_STYLE: Record<ReservationStatus, { color: string; bg: string; borderColor: string }> = {
-  held:      { color: 'warning.dark',  bg: 'warning.light', borderColor: 'warning.main' },
-  submitted: { color: 'warning.dark',  bg: 'warning.light', borderColor: 'warning.main' },
-  confirmed: { color: 'success.dark', bg: 'success.light', borderColor: 'success.main' },
-  failed:    { color: 'error.main',   bg: 'error.contrastText',   borderColor: 'error.main' },
-  expired:   { color: '#6b7280',      bg: '#f3f4f6',       borderColor: '#d1d5db' },
-  cancelled: { color: 'error.main',   bg: 'error.contrastText',   borderColor: 'error.main' },
+  held:        { color: 'warning.dark',  bg: 'warning.light',       borderColor: 'warning.main' },
+  submitted:   { color: 'warning.dark',  bg: 'warning.light',       borderColor: 'warning.main' },
+  confirmed:   { color: 'success.dark',  bg: 'success.light',       borderColor: 'success.main' },
+  checked_in:  { color: 'success.dark',  bg: 'success.light',       borderColor: 'success.main' },
+  checked_out: { color: '#6b7280',       bg: '#f3f4f6',             borderColor: '#d1d5db' },
+  no_show:     { color: 'error.main',    bg: 'error.contrastText',  borderColor: 'error.main' },
+  failed:      { color: 'error.main',    bg: 'error.contrastText',  borderColor: 'error.main' },
+  expired:     { color: '#6b7280',       bg: '#f3f4f6',             borderColor: '#d1d5db' },
+  cancelled:   { color: 'error.main',    bg: 'error.contrastText',  borderColor: 'error.main' },
 };
 
 function StatusPill({ status, t }: { status: ReservationStatus; t: (k: string) => string }) {

--- a/frontend/src/utils/queries.ts
+++ b/frontend/src/utils/queries.ts
@@ -196,7 +196,16 @@ export async function fetchReservationById(id: string): Promise<ReservationRespo
 
 // ─── My Reservations ──────────────────────────────────────────────────────────
 
-export type ReservationStatus = 'held' | 'submitted' | 'confirmed' | 'failed' | 'expired' | 'cancelled';
+export type ReservationStatus =
+  | 'held'
+  | 'submitted'
+  | 'confirmed'
+  | 'checked_in'
+  | 'checked_out'
+  | 'no_show'
+  | 'failed'
+  | 'expired'
+  | 'cancelled';
 
 export interface ReservationSnapshot {
   propertyName: string;

--- a/services/booking-service/eslint.config.mjs
+++ b/services/booking-service/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
   {
-    ignores: ['eslint.config.mjs'],
+    ignores: ['eslint.config.mjs', '**/scripts/**'],
   },
   eslint.configs.recommended,
   ...tseslint.configs.recommendedTypeChecked,

--- a/services/booking-service/scripts/seed.ts
+++ b/services/booking-service/scripts/seed.ts
@@ -585,13 +585,28 @@ function addDays(date: string, days: number): string {
   return d.toISOString().slice(0, 10);
 }
 
+type HistoricalOutcome = "checked_out" | "cancelled" | "no_show";
+
 function historicalReservation(
   resId: string,
   template: FareTemplateName,
   checkIn: string,
   bookerIdx: 1 | 2 | 3,
+  outcome: HistoricalOutcome = "checked_out",
 ) {
   const tpl = FARE_TEMPLATES[template];
+  const reason =
+    outcome === "cancelled"
+      ? "cancelled by guest"
+      : outcome === "no_show"
+        ? "guest did not arrive"
+        : null;
+  // checked_out implies the guest physically arrived; stamp check-in at 14:00 local
+  // (UTC approximation good enough for seed data) so toResponse serializes it.
+  const checkedInAt =
+    outcome === "checked_out"
+      ? new Date(`${checkIn}T14:00:00.000Z`)
+      : null;
   return {
     id: resId,
     property_id: tpl.propertyId,
@@ -601,7 +616,9 @@ function historicalReservation(
     guest_info: GUEST_INFO[bookerIdx - 1],
     check_in: checkIn,
     check_out: addDays(checkIn, tpl.nights),
-    status: "confirmed",
+    status: outcome,
+    reason,
+    checked_in_at: checkedInAt,
     snapshot: tpl.snapshot,
     fare_breakdown: tpl.fare,
     tax_total_usd: tpl.taxTotal,
@@ -611,18 +628,20 @@ function historicalReservation(
   };
 }
 
+// Distribute 14 historical rows: 11 checked_out, 2 cancelled, 1 no_show
+// (≈78/14/7 split — exercises every terminal state in the trips UI).
 const HISTORICAL_RESERVATIONS = [
   // ── PARTNER_1 (Gran Caribe Hospitality Group) ──
   historicalReservation(RES(10), "gran_caribe_deluxe_3n", "2025-08-04", 1),
-  historicalReservation(RES(11), "gran_caribe_suite_4n", "2025-09-12", 1),
+  historicalReservation(RES(11), "gran_caribe_suite_4n", "2025-09-12", 1, "cancelled"),
   historicalReservation(RES(12), "gran_caribe_deluxe_3n", "2025-10-18", 3),
   historicalReservation(RES(13), "gran_caribe_suite_4n", "2025-11-22", 1),
   historicalReservation(RES(14), "gran_caribe_deluxe_3n", "2025-12-05", 3),
-  historicalReservation(RES(15), "gran_caribe_deluxe_3n", "2026-01-08", 1),
+  historicalReservation(RES(15), "gran_caribe_deluxe_3n", "2026-01-08", 1, "no_show"),
   historicalReservation(RES(16), "gran_caribe_suite_4n", "2026-02-19", 3),
   historicalReservation(RES(17), "gran_caribe_deluxe_3n", "2026-04-11", 1),
   // ── PARTNER_2 (Sol Boutique Hotels & Hostales) ──
-  historicalReservation(RES(20), "historico_deluxe_3n", "2025-08-22", 2),
+  historicalReservation(RES(20), "historico_deluxe_3n", "2025-08-22", 2, "cancelled"),
   historicalReservation(RES(21), "hostal_standard_3n", "2025-10-07", 2),
   historicalReservation(RES(22), "historico_deluxe_3n", "2025-11-15", 2),
   historicalReservation(RES(23), "hostal_standard_3n", "2025-12-20", 3),
@@ -702,6 +721,8 @@ async function seed() {
   const ALL_RESERVATIONS = [...RESERVATIONS, ...HISTORICAL_RESERVATIONS];
   console.log(`Seeding ${ALL_RESERVATIONS.length} reservations...`);
   for (const r of ALL_RESERVATIONS) {
+    const reason = "reason" in r ? r.reason : null;
+    const checkedInAt = "checked_in_at" in r ? r.checked_in_at : null;
     await db
       .insertInto("reservations")
       .values({
@@ -714,6 +735,8 @@ async function seed() {
         check_in: r.check_in,
         check_out: r.check_out,
         status: r.status,
+        reason: reason ?? undefined,
+        checked_in_at: checkedInAt ?? undefined,
         snapshot: r.snapshot,
         fare_breakdown: r.fare_breakdown,
         tax_total_usd: r.tax_total_usd,
@@ -724,13 +747,15 @@ async function seed() {
       .onConflict((oc) =>
         oc.column("id").doUpdateSet((eb) => ({
           status: eb.ref("excluded.status"),
+          reason: eb.ref("excluded.reason"),
+          checked_in_at: eb.ref("excluded.checked_in_at"),
           fare_breakdown: eb.ref("excluded.fare_breakdown"),
           grand_total_usd: eb.ref("excluded.grand_total_usd"),
         })),
       )
       .execute();
     console.log(
-      `  ✓ ${r.status.padEnd(9)} ${r.check_in} → ${r.check_out}  booker …${r.booker_id.slice(-4)}  guest ${r.guest_info.firstName} ${r.guest_info.lastName}  total $${r.grand_total_usd}`,
+      `  ✓ ${r.status.padEnd(11)} ${r.check_in} → ${r.check_out}  booker …${r.booker_id.slice(-4)}  guest ${r.guest_info.firstName} ${r.guest_info.lastName}  total $${r.grand_total_usd}`,
     );
   }
 

--- a/services/booking-service/src/events/events.types.ts
+++ b/services/booking-service/src/events/events.types.ts
@@ -6,7 +6,8 @@ export type BookingRoutingKey =
   | "booking.checked_in"
   | "booking.checked_out"
   | "booking.failed"
-  | "booking.expired";
+  | "booking.expired"
+  | "booking.no_show";
 
 export type BookingActor = "guest" | "partner" | "system";
 

--- a/services/booking-service/src/reservations/no-show.service.spec.ts
+++ b/services/booking-service/src/reservations/no-show.service.spec.ts
@@ -1,0 +1,91 @@
+import { NoShowService } from "./no-show.service.js";
+import type { ReservationsRepository } from "./reservations.repository.js";
+import type { ReservationsService } from "./reservations.service.js";
+import type { CacheService } from "../cache/cache.service.js";
+
+function makeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "res-uuid",
+    room_id: "room-uuid",
+    check_in: "2026-05-01",
+    check_out: "2026-05-04",
+    status: "confirmed",
+    ...overrides,
+  };
+}
+
+function makeService({
+  findStaleConfirmed = jest.fn().mockResolvedValue([]),
+  noShow = jest.fn().mockResolvedValue({ id: "res-uuid" }),
+  acquireLock = jest.fn().mockResolvedValue(true),
+}: {
+  findStaleConfirmed?: jest.Mock;
+  noShow?: jest.Mock;
+  acquireLock?: jest.Mock;
+} = {}) {
+  const repo = { findStaleConfirmed } as unknown as ReservationsRepository;
+  const reservationsService = { noShow } as unknown as ReservationsService;
+  const cache = { acquireLock } as unknown as CacheService;
+  return {
+    service: new NoShowService(repo, reservationsService, cache),
+    findStaleConfirmed,
+    noShow,
+    acquireLock,
+  };
+}
+
+describe("NoShowService", () => {
+  describe("markStaleConfirmedAsNoShow", () => {
+    it("skips the sweep when the Redis lock is already held", async () => {
+      const { service, findStaleConfirmed } = makeService({
+        acquireLock: jest.fn().mockResolvedValue(false),
+      });
+
+      await service.markStaleConfirmedAsNoShow();
+
+      expect(findStaleConfirmed).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when no stale confirmed rows exist", async () => {
+      const { service, noShow } = makeService({
+        findStaleConfirmed: jest.fn().mockResolvedValue([]),
+      });
+
+      await service.markStaleConfirmedAsNoShow();
+
+      expect(noShow).not.toHaveBeenCalled();
+    });
+
+    it("invokes service.noShow for each stale row", async () => {
+      const rows = [
+        makeRow({ id: "r1" }),
+        makeRow({ id: "r2" }),
+        makeRow({ id: "r3" }),
+      ];
+      const { service, noShow } = makeService({
+        findStaleConfirmed: jest.fn().mockResolvedValue(rows),
+      });
+
+      await service.markStaleConfirmedAsNoShow();
+
+      expect(noShow).toHaveBeenCalledTimes(3);
+      expect(noShow).toHaveBeenNthCalledWith(1, "r1");
+      expect(noShow).toHaveBeenNthCalledWith(2, "r2");
+      expect(noShow).toHaveBeenNthCalledWith(3, "r3");
+    });
+
+    it("continues processing remaining rows when one transition throws", async () => {
+      const rows = [makeRow({ id: "r1" }), makeRow({ id: "r2" })];
+      const { service, noShow } = makeService({
+        findStaleConfirmed: jest.fn().mockResolvedValue(rows),
+        noShow: jest
+          .fn()
+          .mockRejectedValueOnce(new Error("publisher down"))
+          .mockResolvedValueOnce({ id: "r2" }),
+      });
+
+      await expect(service.markStaleConfirmedAsNoShow()).resolves.not.toThrow();
+      expect(noShow).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/services/booking-service/src/reservations/no-show.service.ts
+++ b/services/booking-service/src/reservations/no-show.service.ts
@@ -1,0 +1,38 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Interval } from "@nestjs/schedule";
+import { ReservationsRepository } from "./reservations.repository.js";
+import { ReservationsService } from "./reservations.service.js";
+import { CacheService } from "../cache/cache.service.js";
+
+const NO_SHOW_INTERVAL_MS = 3_600_000; // 1 hour
+const LOCK_KEY = "booking:no-show:lock";
+const LOCK_TTL_SECONDS = 3_700; // interval + 100s buffer
+
+@Injectable()
+export class NoShowService {
+  private readonly logger = new Logger(NoShowService.name);
+
+  constructor(
+    private readonly reservationsRepo: ReservationsRepository,
+    private readonly reservationsService: ReservationsService,
+    private readonly cache: CacheService,
+  ) {}
+
+  @Interval(NO_SHOW_INTERVAL_MS)
+  async markStaleConfirmedAsNoShow(): Promise<void> {
+    const acquired = await this.cache.acquireLock(LOCK_KEY, LOCK_TTL_SECONDS);
+    if (!acquired) return;
+
+    const stale = await this.reservationsRepo.findStaleConfirmed();
+
+    for (const row of stale) {
+      try {
+        await this.reservationsService.noShow(row.id);
+      } catch (err) {
+        this.logger.warn(
+          `Failed to mark reservation ${row.id} as no_show: ${err}`,
+        );
+      }
+    }
+  }
+}

--- a/services/booking-service/src/reservations/reservations.module.ts
+++ b/services/booking-service/src/reservations/reservations.module.ts
@@ -3,6 +3,7 @@ import { ReservationsController } from "./reservations.controller.js";
 import { ReservationsService } from "./reservations.service.js";
 import { ReservationsRepository } from "./reservations.repository.js";
 import { HoldExpiryService } from "./hold-expiry.service.js";
+import { NoShowService } from "./no-show.service.js";
 import { FareCalculatorService } from "../fare/fare-calculator.service.js";
 import { HoldsService } from "./holds.service.js";
 import { ClientsModule } from "../clients/clients.module.js";
@@ -24,6 +25,7 @@ import { PublisherModule } from "../events/publisher.module.js";
     ReservationsService,
     ReservationsRepository,
     HoldExpiryService,
+    NoShowService,
     FareCalculatorService,
     HoldsService,
   ],

--- a/services/booking-service/src/reservations/reservations.repository.spec.ts
+++ b/services/booking-service/src/reservations/reservations.repository.spec.ts
@@ -390,6 +390,55 @@ describe("ReservationsRepository", () => {
     });
   });
 
+  describe("findStaleConfirmed", () => {
+    it("returns confirmed rows whose check_in is in the past", async () => {
+      const rows = [
+        makeRow({ id: "r1", status: "confirmed" }),
+        makeRow({ id: "r2", status: "confirmed" }),
+      ];
+      const db = makeDb({ many: rows });
+      const repo = new ReservationsRepository(db);
+
+      const result = await repo.findStaleConfirmed();
+
+      expect(db.selectFrom).toHaveBeenCalledWith("reservations");
+      expect(db.where).toHaveBeenCalledWith("status", "=", "confirmed");
+      expect(db.where).toHaveBeenCalledWith(
+        "check_in",
+        "<",
+        expect.any(String),
+      );
+      expect(result).toBe(rows);
+    });
+  });
+
+  describe("markNoShow", () => {
+    it("transitions status to no_show with reason and returns the row", async () => {
+      const noShow = makeRow({
+        status: "no_show",
+        reason: "guest did not arrive",
+      });
+      const db = makeDb({ single: noShow });
+      const repo = new ReservationsRepository(db);
+
+      const result = await repo.markNoShow("res-uuid", "guest did not arrive");
+
+      expect(db.updateTable).toHaveBeenCalledWith("reservations");
+      expect(db.where).toHaveBeenCalledWith("id", "=", "res-uuid");
+      expect(db.where).toHaveBeenCalledWith("status", "=", "confirmed");
+      expect(result).toBe(noShow);
+    });
+
+    it("returns undefined when row is not confirmed (idempotency guard)", async () => {
+      const db = makeDb({ single: undefined });
+      const repo = new ReservationsRepository(db);
+
+      const result = await repo.markNoShow("already-checked-in", "no arrival");
+
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe("fail", () => {
     it("transitions status from submitted to failed and returns the row", async () => {
       const failed = makeRow({ status: "failed", reason: "card declined" });

--- a/services/booking-service/src/reservations/reservations.repository.ts
+++ b/services/booking-service/src/reservations/reservations.repository.ts
@@ -251,6 +251,28 @@ export class ReservationsRepository {
       .executeTakeFirst();
   }
 
+  async findStaleConfirmed(): Promise<ReservationRow[]> {
+    return this.db
+      .selectFrom("reservations")
+      .where("status", "=", "confirmed")
+      .where("check_in", "<", new Date().toISOString().slice(0, 10))
+      .selectAll()
+      .execute();
+  }
+
+  async markNoShow(
+    id: string,
+    reason: string,
+  ): Promise<ReservationRow | undefined> {
+    return this.db
+      .updateTable("reservations")
+      .set({ status: "no_show", reason, updated_at: new Date() })
+      .where("id", "=", id)
+      .where("status", "=", "confirmed")
+      .returningAll()
+      .executeTakeFirst();
+  }
+
   async modify(
     id: string,
     fields: ModifyReservationFields,

--- a/services/booking-service/src/reservations/reservations.service.spec.ts
+++ b/services/booking-service/src/reservations/reservations.service.spec.ts
@@ -837,6 +837,63 @@ describe("ReservationsService", () => {
     });
   });
 
+  describe("noShow", () => {
+    it("returns mapped response for a confirmed reservation", async () => {
+      const noShowRow = makeRow({
+        status: "no_show",
+        reason: "guest did not arrive",
+      });
+      reservationsRepo.markNoShow = jest.fn().mockResolvedValue(noShowRow);
+
+      const result = await service.noShow("res-uuid");
+
+      expect(reservationsRepo.markNoShow).toHaveBeenCalledWith(
+        "res-uuid",
+        "guest did not arrive",
+      );
+      expect(result).toEqual({ id: noShowRow.id });
+    });
+
+    it("does not release inventory (no-show is billable)", async () => {
+      const noShowRow = makeRow({ status: "no_show" });
+      reservationsRepo.markNoShow = jest.fn().mockResolvedValue(noShowRow);
+
+      await service.noShow("res-uuid");
+
+      expect(inventoryClient.unhold).not.toHaveBeenCalled();
+      expect(inventoryClient.release).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined without publishing when row is not confirmed", async () => {
+      reservationsRepo.markNoShow = jest.fn().mockResolvedValue(undefined);
+
+      const result = await service.noShow("res-uuid");
+
+      expect(result).toBeUndefined();
+      expect(publisher.publish).not.toHaveBeenCalled();
+    });
+
+    it("publishes booking.no_show with actor=system and the reason", async () => {
+      const noShowRow = makeRow({
+        status: "no_show",
+        reason: "guest did not arrive",
+      });
+      reservationsRepo.markNoShow = jest.fn().mockResolvedValue(noShowRow);
+
+      await service.noShow("res-uuid");
+
+      expect(publisher.publish).toHaveBeenCalledWith(
+        "booking.no_show",
+        expect.objectContaining({
+          routingKey: "booking.no_show",
+          reservationId: noShowRow.id,
+          actor: "system",
+          reason: "guest did not arrive",
+        }),
+      );
+    });
+  });
+
   // ─── confirm ────────────────────────────────────────────────────────────────
 
   describe("confirm", () => {

--- a/services/booking-service/src/reservations/reservations.service.ts
+++ b/services/booking-service/src/reservations/reservations.service.ts
@@ -263,6 +263,16 @@ export class ReservationsService {
     return this.reservationsRepo.toResponse(row);
   }
 
+  async noShow(id: string, reason = "guest did not arrive") {
+    const row = await this.reservationsRepo.markNoShow(id, reason);
+    if (!row) return;
+
+    // No inventory.unhold: no-show is billable revenue, the room stays consumed
+    // for the stay window (industry standard, matches cancellation-with-penalty).
+    this.emit("booking.no_show", row, "system");
+    return this.reservationsRepo.toResponse(row);
+  }
+
   async modify(
     id: string,
     dto: ModifyReservationDto,

--- a/services/notification-service/src/events/events.service.spec.ts
+++ b/services/notification-service/src/events/events.service.spec.ts
@@ -155,14 +155,14 @@ describe("EventsService.onModuleInit", () => {
     expect(amqp.connect).not.toHaveBeenCalled();
   });
 
-  it("subscribes to all 6 booking routing keys", async () => {
+  it("subscribes to all 7 booking routing keys", async () => {
     process.env.MESSAGE_BROKER_TYPE = "rabbitmq";
 
     await service.onModuleInit();
 
-    expect(channel.assertQueue).toHaveBeenCalledTimes(6);
-    expect(channel.bindQueue).toHaveBeenCalledTimes(6);
-    expect(channel.consume).toHaveBeenCalledTimes(6);
+    expect(channel.assertQueue).toHaveBeenCalledTimes(7);
+    expect(channel.bindQueue).toHaveBeenCalledTimes(7);
+    expect(channel.consume).toHaveBeenCalledTimes(7);
   });
 
   it("logs error and does not throw when RabbitMQ connection fails", async () => {

--- a/services/notification-service/src/events/events.service.ts
+++ b/services/notification-service/src/events/events.service.ts
@@ -28,6 +28,7 @@ const ROUTING_KEYS: BookingRoutingKey[] = [
   "booking.checked_out",
   "booking.failed",
   "booking.expired",
+  "booking.no_show",
 ];
 
 @Injectable()

--- a/services/notification-service/src/events/templates/booking-no-show.ts
+++ b/services/notification-service/src/events/templates/booking-no-show.ts
@@ -1,0 +1,6 @@
+import type { BookingEvent, RenderedMessage } from "../types.js";
+
+// No guest message fires on no-show today.
+export function render(_event: BookingEvent): RenderedMessage | null {
+  return null;
+}

--- a/services/notification-service/src/events/templates/index.ts
+++ b/services/notification-service/src/events/templates/index.ts
@@ -5,6 +5,7 @@ import { render as checkedIn } from "./booking-checked-in.js";
 import { render as checkedOut } from "./booking-checked-out.js";
 import { render as failed } from "./booking-failed.js";
 import { render as expired } from "./booking-expired.js";
+import { render as noShow } from "./booking-no-show.js";
 
 export const templates: Record<BookingRoutingKey, Renderer> = {
   "booking.cancelled": cancelled,
@@ -13,4 +14,5 @@ export const templates: Record<BookingRoutingKey, Renderer> = {
   "booking.checked_out": checkedOut,
   "booking.failed": failed,
   "booking.expired": expired,
+  "booking.no_show": noShow,
 };

--- a/services/notification-service/src/events/types.ts
+++ b/services/notification-service/src/events/types.ts
@@ -6,7 +6,8 @@ export type BookingRoutingKey =
   | "booking.checked_in"
   | "booking.checked_out"
   | "booking.failed"
-  | "booking.expired";
+  | "booking.expired"
+  | "booking.no_show";
 
 export type BookingActor = "guest" | "partner" | "system";
 


### PR DESCRIPTION
## Descripción

Añade el estado terminal `no_show` a la máquina de estados de reservas y arregla la página `/trips` para que muestre las reservas en estados terminales (que hoy se descartaban silenciosamente).

**Por qué:** una reserva `confirmed` cuya fecha de check-in ya pasó quedaba indefinidamente en `confirmed`, lo que distorsiona reportes de revenue y no refleja la realidad (PMS estándar diferencia `no_show` de `cancelled` porque es renta facturable). Además, las reservas pasadas (`checked_out`, `expired`, etc.) no aparecían en `/trips` aunque existieran en la BD.

### Cambios principales

- **booking-service**
  - Nuevo `NoShowService` (job horario, mismo patrón que `HoldExpiryService`) que marca como `no_show` todas las reservas `confirmed` con `check_in < CURRENT_DATE`. No libera inventario — el cuarto queda consumido para la ventana de estadía (renta facturable, no cancelable).
  - Nuevos métodos repo: `findStaleConfirmed()` y `markNoShow(id, reason)`.
  - Nuevo método servicio: `noShow(id, reason?)` que emite `booking.no_show` con `actor=system`.
  - `BookingRoutingKey` extendido con `"booking.no_show"`.

- **notification-service**
  - Plantilla `booking-no-show.ts` que retorna `null` (sin email por ahora, mismo patrón que `booking-expired`).
  - Subscripción al routing key nuevo (`booking-no_show` → `notification-booking-no_show`).

- **frontend (`/trips`)**
  - `ACTIVE_STATUSES` ahora incluye `checked_in` (huésped en hotel).
  - `PAST_STATUSES` ahora incluye `checked_out`, `no_show`, `expired` (antes se descartaban). Las reservas terminales aparecen bajo la sección "Pasadas".
  - Labels i18n y estilos de chip para los 3 nuevos estados (es/en).

- **Seeds**
  - Las 14 reservas históricas se redistribuyen como **11 `checked_out` / 2 `cancelled` / 1 `no_show`** (~78/14/7) para ejercitar cada estado terminal en la UI.
  - `checked_out` rows incluyen `checked_in_at` timestamp.

- **Docs (`CLAUDE.md`)**
  - Diagrama de máquina de estados extendido para incluir `confirmed → checked_in → checked_out`, `confirmed → no_show`.
  - Tabla de estados con marcadores terminales, tabla de transiciones con el nuevo job horario, nota sobre la semántica de revenue.
  - Tabla de routing keys actualizada.

- **Chore**
  - `eslint.config.mjs` de booking-service ignora `**/scripts/**` — la carpeta `scripts/` no está en ningún tsconfig y rompía el pre-commit hook al modificar `seed.ts`.

## Tipo de cambio
- [x] Nueva funcionalidad
- [ ] Corrección de error
- [ ] Refactor
- [x] Documentación
- [ ] Infraestructura / configuración

## Cómo probar

1. **Reseed**: `DATABASE_URL=postgres://postgres:postgres@localhost:5436/travelhub pnpm exec nx run booking-service:seed`. Verifica el reparto:
   ```sql
   SELECT status, COUNT(*) FROM reservations GROUP BY status ORDER BY status;
   -- esperado: cancelled:2, checked_out:11, confirmed:4, no_show:1, submitted:1
   ```
2. **UI**: inicia frontend (`pnpm run serve:frontend`) + api-gateway + booking-service. Loguéate con un booker que tenga histórico (p. ej. `carlos.garcia@example.com`) y abre `/trips`. Las reservas terminales deben aparecer bajo "Pasadas" con sus respectivos chips traducidos.
3. **Transición automática**: inserta manualmente una reserva `confirmed` con `check_in = CURRENT_DATE - 1`. Inicia booking-service y espera ≤1 hora — el `NoShowService` la moverá a `no_show` y emitirá el evento (verlo en logs de RabbitMQ).
4. **Tests**:
   - `pnpm exec nx test booking-service` (295 pruebas)
   - `pnpm exec nx test notification-service` (65 pruebas)
   - `pnpm exec nx test frontend` (598 pruebas)
5. **Lint**: `pnpm run lint` en booking-service / notification-service / frontend → 0 errores.

## Issues relacionados
N/A

## Checklist
- [x] El código compila sin errores
- [x] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [x] El linter no reporta errores (`pnpm run lint`)

## Pendiente / follow-up
- **Pulumi**: el topic `booking-no_show` y la subscripción `notification-booking-no_show` necesitan declararse en la capa de infraestructura cuando se toque el deploy. Los servicios no crean recursos Pub/Sub dinámicamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)