### PR TITLE
feat(mobile): rediseñar flujo de reserva sin sesión + useBookingFlow

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -73,7 +73,12 @@ export default function LoginPage() {
         <h1 className="text-2xl font-bold text-gray-900 mb-1">{t('login.title')}</h1>
         <p className="text-sm text-gray-600 mb-6">
           {t('login.no_account')}{' '}
-          <Link href="/register" underline="hover">
+          <Link
+            component="button"
+            type="button"
+            underline="hover"
+            onClick={() => navigate({ to: '/register' })}
+          >
             {t('login.register_link')}
           </Link>
         </p>

--- a/mobile/app/(auth)/login-mfa.tsx
+++ b/mobile/app/(auth)/login-mfa.tsx
@@ -4,16 +4,17 @@ import { Text, TextInput, Button, HelperText, useTheme } from 'react-native-pape
 import { AppHeader } from '@/components/ui/app-header';
 import { AppCard } from '@/components/ui/app-card';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useRouter, useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
 import { AuthApiError } from '@/services/auth-api';
+import { useBookingFlow } from '@/hooks/useBookingFlow';
 
 export default function LoginMfaScreen() {
   const theme = useTheme();
-  const router = useRouter();
   const { t } = useTranslation();
   const auth = useAuth();
+  const { resumeAfterAuth } = useBookingFlow();
   const { challengeId, email } = useLocalSearchParams<{ challengeId: string; email: string }>();
 
   const [code, setCode] = useState('');
@@ -25,7 +26,7 @@ export default function LoginMfaScreen() {
     setLoading(true);
     try {
       await auth.verifyMfa(challengeId, code.trim());
-      router.replace('/(tabs)');
+      resumeAfterAuth();
     } catch (err) {
       if (err instanceof AuthApiError && err.status === 401) {
         setApiError(t('loginMfa.errorInvalidCode'));

--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -8,6 +8,8 @@ import { useTranslation } from 'react-i18next';
 import { AppCard } from '@/components/ui/app-card';
 import { validateRegisterFields, hasErrors } from '@/utils/register-validation';
 import type { RegisterFields, RegisterErrors } from '@/utils/register-validation';
+import { useAuth } from '@/hooks/useAuth';
+import { getCheckoutIntent } from '@/services/checkout-store';
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
 
@@ -15,6 +17,7 @@ export default function RegisterScreen() {
   const theme = useTheme();
   const router = useRouter();
   const { t } = useTranslation();
+  const { login } = useAuth();
 
   const [fields, setFields] = useState<RegisterFields>({
     firstName: '',
@@ -66,6 +69,17 @@ export default function RegisterScreen() {
         return;
       }
 
+      if (getCheckoutIntent()) {
+        try {
+          const result = await login(fields.email.trim().toLowerCase(), fields.password);
+          router.replace(
+            `/login-mfa?challengeId=${result.challengeId}&email=${encodeURIComponent(result.email)}`,
+          );
+          return;
+        } catch {
+          // Account created but auto-login failed — fall through to the success screen.
+        }
+      }
       router.replace('/register-success');
     } catch {
       setApiError(t('register.errorGeneric'));

--- a/mobile/app/(auth)/sign-in-required.tsx
+++ b/mobile/app/(auth)/sign-in-required.tsx
@@ -1,0 +1,63 @@
+import { KeyboardAvoidingView, Platform, ScrollView, StyleSheet } from 'react-native';
+import { Button, Divider, Text, useTheme } from 'react-native-paper';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { AppHeader } from '@/components/ui/app-header';
+import { AppCard } from '@/components/ui/app-card';
+import { LoginForm } from '@/components/auth/login-form';
+
+export default function SignInRequiredScreen() {
+  const theme = useTheme();
+  const router = useRouter();
+  const { t } = useTranslation();
+
+  return (
+    <SafeAreaView style={[styles.safeArea, { backgroundColor: '#f8f9ff' }]} edges={['bottom']}>
+      <AppHeader title={t('signInRequired.title')} showBack />
+
+      <KeyboardAvoidingView style={{ flex: 1 }} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          <AppCard style={styles.card}>
+            <Text variant="headlineSmall" style={[styles.heading, { color: theme.colors.onBackground }]}>
+              {t('signInRequired.heading')}
+            </Text>
+            <Text variant="bodyMedium" style={[styles.subheading, { color: theme.colors.onSurfaceVariant }]}>
+              {t('signInRequired.subheading')}
+            </Text>
+
+            <LoginForm />
+
+            <Divider style={styles.divider} />
+
+            <Text variant="bodyMedium" style={[styles.noAccount, { color: theme.colors.onSurfaceVariant }]}>
+              {t('signInRequired.noAccount')}
+            </Text>
+            <Button
+              mode="contained"
+              onPress={() => router.push('/register')}
+              textColor={theme.colors.onPrimary}
+              contentStyle={styles.btnContent}
+              style={[styles.btn, { borderColor: theme.colors.primary }]}
+              testID="btn-create-account"
+            >
+              {t('signInRequired.createAccount')}
+            </Button>
+          </AppCard>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: { flex: 1 },
+  content: { padding: 16, flexGrow: 1 },
+  card: { padding: 24 },
+  heading: { fontWeight: '700', marginBottom: 8 },
+  subheading: { marginBottom: 20 },
+  divider: { marginVertical: 20 },
+  noAccount: { textAlign: 'center', marginBottom: 12 },
+  btnContent: { paddingVertical: 6 },
+  btn: { borderRadius: 10 },
+});

--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -1,13 +1,19 @@
 import { Tabs } from 'expo-router';
 import React from 'react';
+import { StyleSheet, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 
 import { HapticTab } from '@/components/haptic-tab';
 import { Colors } from '@/constants/theme';
+import { useAuth } from '@/hooks/useAuth';
+import { usePendingReservation } from '@/hooks/usePendingReservation';
 
 export default function TabLayout() {
   const { t } = useTranslation();
+  const { user } = useAuth();
+  const hasPending = usePendingReservation();
+  const showTripsDot = hasPending && !!user;
 
   return (
     <Tabs
@@ -27,7 +33,17 @@ export default function TabLayout() {
         name="trips"
         options={{
           title: t('tabs.bookings'),
-          tabBarIcon: ({ color }) => <MaterialIcons name="event-available" size={26} color={color} />,
+          tabBarIcon: ({ color }) => (
+            <View>
+              <MaterialIcons name="event-available" size={26} color={color} />
+              {showTripsDot && (
+                <View
+                  style={styles.pendingDot}
+                  accessibilityLabel={t('tabs.pendingReservation')}
+                />
+              )}
+            </View>
+          ),
         }}
       />
       <Tabs.Screen
@@ -40,3 +56,17 @@ export default function TabLayout() {
     </Tabs>
   );
 }
+
+const styles = StyleSheet.create({
+  pendingDot: {
+    position: 'absolute',
+    top: -2,
+    right: -4,
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: '#f59e0b',
+    borderWidth: 1.5,
+    borderColor: '#fff',
+  },
+});

--- a/mobile/app/(tabs)/account.tsx
+++ b/mobile/app/(tabs)/account.tsx
@@ -1,50 +1,18 @@
-import { useState } from 'react';
 import { StyleSheet, KeyboardAvoidingView, Platform, ScrollView, View } from 'react-native';
-import { Text, TextInput, Button, HelperText, TouchableRipple, Icon , useTheme } from 'react-native-paper';
+import { Text, Button, TouchableRipple, Icon , useTheme } from 'react-native-paper';
 import { AppHeader } from '@/components/ui/app-header';
 import { AppCard } from '@/components/ui/app-card';
+import { LoginForm } from '@/components/auth/login-form';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '@/hooks/useAuth';
-import { AuthApiError } from '@/services/auth-api';
 
 export default function AccountScreen() {
   const theme = useTheme();
   const router = useRouter();
   const { t } = useTranslation();
-  const { user, login, logout } = useAuth();
-
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [showPassword, setShowPassword] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [apiError, setApiError] = useState<string | null>(null);
-  const [emailError, setEmailError] = useState<string | null>(null);
-  const [passwordError, setPasswordError] = useState<string | null>(null);
-
-  const handleSignIn = async () => {
-    setApiError(null);
-    const emailMissing = !email.trim();
-    const passwordMissing = !password;
-    setEmailError(emailMissing ? t('account.errorEmailRequired') : null);
-    setPasswordError(passwordMissing ? t('account.errorPasswordRequired') : null);
-    if (emailMissing || passwordMissing) return;
-    setLoading(true);
-    try {
-      const result = await login(email.trim().toLowerCase(), password);
-      router.push(`/login-mfa?challengeId=${result.challengeId}&email=${encodeURIComponent(result.email)}`);
-    } catch (err) {
-      if (err instanceof AuthApiError && err.status === 401) {
-        setApiError(t('account.errorInvalidCredentials'));
-      } else {
-        setApiError(t('account.errorGeneric'));
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
-
+  const { user, logout } = useAuth();
 
   return (
     <SafeAreaView style={[styles.safeArea, { backgroundColor: '#f8f9ff' }]} edges={[]}>
@@ -78,63 +46,7 @@ export default function AccountScreen() {
                 {t('account.heading')}
               </Text>
 
-              <View style={styles.field}>
-                <TextInput
-                  label={t('account.email')}
-                  value={email}
-                  onChangeText={v => { setEmail(v); setEmailError(null); }}
-                  mode="outlined"
-                  keyboardType="email-address"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  left={<TextInput.Icon icon="email-outline" />}
-                  style={styles.input}
-                  error={!!emailError}
-                  testID="input-email"
-                />
-                {emailError ? <HelperText type="error" visible>{emailError}</HelperText> : null}
-              </View>
-
-              <View style={styles.field}>
-                <TextInput
-                  label={t('account.password')}
-                  value={password}
-                  onChangeText={v => { setPassword(v); setPasswordError(null); }}
-                  mode="outlined"
-                  secureTextEntry={!showPassword}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  left={<TextInput.Icon icon="lock-outline" />}
-                  right={
-                    <TextInput.Icon
-                      icon={showPassword ? 'eye-off-outline' : 'eye-outline'}
-                      onPress={() => setShowPassword(v => !v)}
-                    />
-                  }
-                  style={styles.input}
-                  error={!!passwordError}
-                  testID="input-password"
-                />
-                {passwordError ? <HelperText type="error" visible>{passwordError}</HelperText> : null}
-              </View>
-
-              {apiError ? (
-                <HelperText type="error" visible style={styles.apiError}>{apiError}</HelperText>
-              ) : null}
-
-              <Button
-                mode="contained"
-                onPress={handleSignIn}
-                loading={loading}
-                disabled={loading}
-                buttonColor={theme.colors.secondary}
-                textColor={theme.colors.onSecondary}
-                contentStyle={styles.btnContent}
-                style={styles.btn}
-                testID="btn-signin"
-              >
-                {t('account.signin')}
-              </Button>
+              <LoginForm />
 
               <Button
                 mode="contained"
@@ -142,7 +54,7 @@ export default function AccountScreen() {
                 buttonColor={theme.colors.primary}
                 textColor={theme.colors.onPrimary}
                 contentStyle={styles.btnContent}
-                style={styles.btn}
+                style={[styles.btn, styles.signupBtn]}
                 testID="btn-signup"
               >
                 {t('account.signup')}
@@ -178,11 +90,9 @@ const styles = StyleSheet.create({
   content: { padding: 16, flexGrow: 1 },
   card: { padding: 24 },
   heading: { fontWeight: '700', marginBottom: 16 },
-  apiError: { marginBottom: 8, fontSize: 14 },
-  field: { marginBottom: 12 },
-  input: { backgroundColor: '#fff' },
   btnContent: { paddingVertical: 6 },
   btn: { borderRadius: 10, marginBottom: 12 },
+  signupBtn: { marginTop: 12 },
   spacer: { height: 48 },
   outlinedItem: {
     borderWidth: 1,

--- a/mobile/app/(tabs)/trips.tsx
+++ b/mobile/app/(tabs)/trips.tsx
@@ -30,7 +30,8 @@ import {
   type Reservation,
   type ReservationStatus,
 } from '@/services/bookings-cache';
-import { rebuildIntent, setCheckoutIntent } from '@/services/checkout-store';
+import { setPendingReservation } from '@/services/pending-reservations-store';
+import { useBookingFlow } from '@/hooks/useBookingFlow';
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
 
@@ -309,6 +310,11 @@ export default function TripsScreen() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Keep the tab-bar dot in sync with the held reservations actually loaded
+  useEffect(() => {
+    setPendingReservation(reservations.some((r) => r.status === 'held'));
+  }, [reservations]);
+
   // Sync when tab comes into focus (covers post-login navigation)
   useFocusEffect(
     useCallback(() => {
@@ -361,26 +367,15 @@ export default function TripsScreen() {
     [router],
   );
 
-  /**
-   * Permite al usuario retomar el flujo de checkout para completar el pago
-   * de una reserva "held" o reintentar una reserva "failed".
-   */
+  const { resumeHeld } = useBookingFlow();
+
   const handleCompletePayment = useCallback(
     (reservation: Reservation) => {
-      const intent = rebuildIntent(reservation);
-      
-      if (!intent) {
-        Alert.alert(
-          t('bookings.errorTitle'),
-          t('bookings.errorRebuildIntent'),
-        );
-        return;
+      if (!resumeHeld(reservation)) {
+        Alert.alert(t('bookings.errorTitle'), t('bookings.errorRebuildIntent'));
       }
-
-      setCheckoutIntent(intent);
-      router.push('/booking/checkout');
     },
-    [router, t],
+    [resumeHeld, t],
   );
 
   // ─── Render states ────────────────────────────────────────────────────────────

--- a/mobile/app/booking/checkout.tsx
+++ b/mobile/app/booking/checkout.tsx
@@ -24,28 +24,9 @@ import { useStripe } from '@/services/stripe-wrapper';
 
 import { useAuth } from '@/hooks/useAuth';
 import { getCheckoutIntent, clearCheckoutIntent } from '@/services/checkout-store';
+import { useBookingFlow, type CreatedReservation } from '@/hooks/useBookingFlow';
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
-
-// ─── Types ─────────────────────────────────────────────────────────────────────
-
-interface FareBreakdown {
-  nights: number;
-  roomRateUsd: number;
-  subtotalUsd: number;
-  taxes: { name: string; amountUsd: number }[];
-  fees: { name: string; totalUsd: number }[];
-  taxTotalUsd: number;
-  feeTotalUsd: number;
-  totalUsd: number;
-}
-
-interface Reservation {
-  id: string;
-  grandTotalUsd: number;
-  holdExpiresAt: string;
-  fareBreakdown: FareBreakdown;
-}
 
 // ─── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -109,8 +90,9 @@ export default function CheckoutScreen() {
   const { initPaymentSheet, presentPaymentSheet } = useStripe();
 
   const intent = useRef(getCheckoutIntent()).current;
+  const { createReservation: createReservationHook } = useBookingFlow();
 
-  const [reservation, setReservation] = useState<Reservation | null>(null);
+  const [reservation, setReservation] = useState<CreatedReservation | null>(null);
   const [loadingReservation, setLoadingReservation] = useState(true);
   const [reservationError, setReservationError] = useState<string | null>(null);
 
@@ -131,81 +113,30 @@ export default function CheckoutScreen() {
 
   const createReservation = useCallback(async () => {
     if (!intent || !token || !user || reservationCreatedRef.current) return;
-    
+
     reservationCreatedRef.current = true;
     setLoadingReservation(true);
     setReservationError(null);
     try {
-      const payload = {
-        propertyId: intent.propertyId,
-        roomId: intent.roomId,
-        partnerId: intent.partnerId,
-        bookerId: user.id,
-        checkIn: intent.checkIn,
-        checkOut: intent.checkOut,
-      };
-      
-      console.log('[Checkout] Creating reservation with:', payload);
-      console.log('[Checkout] Property:', intent.propertyName);
-      console.log('[Checkout] Room type:', intent.roomType);
-      console.log('[Checkout] Dates:', intent.checkIn, 'to', intent.checkOut);
-      console.log('[Checkout] API endpoint:', `${API_BASE}/api/booking/reservations`);
-      
-      const res = await fetch(`${API_BASE}/api/booking/reservations`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(payload),
-      });
-      
-      if (!res.ok) {
-        const errorText = await res.text();
-        console.error('[Checkout] Reservation creation failed:', res.status, errorText);
-        
-        // Extraer mensaje específico del backend
-        let backendMessage = t('checkout.errorHold');
-        try {
-          const errorJson = JSON.parse(errorText);
-          if (errorJson.message) {
-            console.error('[Checkout] Backend error details:', errorJson.message);
-            backendMessage = errorJson.message; // Usar mensaje real del backend
-          } else if (errorJson.error) {
-            backendMessage = errorJson.error;
-          }
-        } catch {
-          // No es JSON, usar el texto plano si existe
-          if (errorText && errorText.length < 200) {
-            backendMessage = errorText;
-          }
-        }
-        throw new Error(backendMessage);
-      }
-      
-      const data = (await res.json()) as Reservation;
+      const data = await createReservationHook();
       console.log('[Checkout] Reservation created successfully:', data.id);
       setReservation(data);
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : t('checkout.errorHold');
       console.error('[Checkout] Error:', errorMsg);
-      
-      // En desarrollo, mostrar detalles del error
       if (__DEV__) {
-        console.error('[Checkout] Full error details:', err);
         Alert.alert(
           'Error de Reserva (DEV)',
           `${errorMsg}\n\nRevisa la consola para más detalles.`,
-          [{ text: 'OK' }]
+          [{ text: 'OK' }],
         );
       }
-      
       setReservationError(errorMsg);
       reservationCreatedRef.current = false; // Allow retry
     } finally {
       setLoadingReservation(false);
     }
-  }, [intent, token, user, t]);
+  }, [intent, token, user, t, createReservationHook]);
 
   useEffect(() => {
     if (!token || !user) {
@@ -369,7 +300,7 @@ export default function CheckoutScreen() {
   if (!intent) return null;
 
   return (
-    <SafeAreaView style={[styles.safe, { backgroundColor: theme.colors.background }]} edges={['top']}>
+    <SafeAreaView style={[styles.safe, { backgroundColor: theme.colors.background }]} edges={['bottom']}>
       <AppHeader title={t('checkout.title')} showBack />
 
       <KeyboardAvoidingView

--- a/mobile/app/property/[id].tsx
+++ b/mobile/app/property/[id].tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   Dimensions,
   FlatList,
   Image,
@@ -30,8 +29,7 @@ import {
 } from 'react-native-paper';
 import { Calendar } from 'react-native-calendars';
 import { Ionicons } from '@expo/vector-icons';
-import { useAuth } from '@/hooks/useAuth';
-import { setCheckoutIntent } from '@/services/checkout-store';
+import { useBookingFlow } from '@/hooks/useBookingFlow';
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
 
@@ -305,8 +303,6 @@ function DatePickerModal({ visible, checkIn, checkOut, onConfirm, onCancel }: Da
 
 export default function PropertyDetailScreen() {
   const router = useRouter();
-  const { t } = useTranslation();
-  const { user } = useAuth();
   const { id, checkIn: qIn, checkOut: qOut, guests: qGuests } =
     useLocalSearchParams<{
       id: string;
@@ -451,18 +447,12 @@ export default function PropertyDetailScreen() {
         ? [property.thumbnailUrl]
         : [];
 
+  const { book } = useBookingFlow();
+
   const handleBook = useCallback(
     (room: SearchRoom) => {
-      if (!checkIn || !checkOut) {
-        Alert.alert(t('property.selectDatesTitle'), t('property.selectDatesMsg'));
-        return;
-      }
-      if (!user) {
-        router.push('/(tabs)/account');
-        return;
-      }
       if (!property) return;
-      setCheckoutIntent({
+      book({
         propertyId: property.id,
         propertyName: property.name,
         propertyCity: property.city,
@@ -475,9 +465,8 @@ export default function PropertyDetailScreen() {
         guests,
         estimatedTotalUsd: room.estimatedTotalUsd,
       });
-      router.push('/booking/checkout');
     },
-    [checkIn, checkOut, user, property, images, guests, router, t],
+    [book, property, images, guests, checkIn, checkOut],
   );
 
   const showDescPreview = description.length > DESCRIPTION_PREVIEW && !descExpanded;

--- a/mobile/components/auth/login-form.tsx
+++ b/mobile/components/auth/login-form.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { Button, HelperText, TextInput, useTheme } from 'react-native-paper';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '@/hooks/useAuth';
+import { AuthApiError } from '@/services/auth-api';
+
+export function LoginForm() {
+  const theme = useTheme();
+  const router = useRouter();
+  const { t } = useTranslation();
+  const { login } = useAuth();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [apiError, setApiError] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+
+  const handleSignIn = async () => {
+    setApiError(null);
+    const emailMissing = !email.trim();
+    const passwordMissing = !password;
+    setEmailError(emailMissing ? t('account.errorEmailRequired') : null);
+    setPasswordError(passwordMissing ? t('account.errorPasswordRequired') : null);
+    if (emailMissing || passwordMissing) return;
+    setLoading(true);
+    try {
+      const result = await login(email.trim().toLowerCase(), password);
+      router.push(`/login-mfa?challengeId=${result.challengeId}&email=${encodeURIComponent(result.email)}`);
+    } catch (err) {
+      if (err instanceof AuthApiError && err.status === 401) {
+        setApiError(t('account.errorInvalidCredentials'));
+      } else {
+        setApiError(t('account.errorGeneric'));
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View>
+      <View style={styles.field}>
+        <TextInput
+          label={t('account.email')}
+          value={email}
+          onChangeText={v => { setEmail(v); setEmailError(null); }}
+          mode="outlined"
+          keyboardType="email-address"
+          autoCapitalize="none"
+          autoCorrect={false}
+          left={<TextInput.Icon icon="email-outline" />}
+          style={styles.input}
+          error={!!emailError}
+          testID="input-email"
+        />
+        {emailError ? <HelperText type="error" visible>{emailError}</HelperText> : null}
+      </View>
+
+      <View style={styles.field}>
+        <TextInput
+          label={t('account.password')}
+          value={password}
+          onChangeText={v => { setPassword(v); setPasswordError(null); }}
+          mode="outlined"
+          secureTextEntry={!showPassword}
+          autoCapitalize="none"
+          autoCorrect={false}
+          left={<TextInput.Icon icon="lock-outline" />}
+          right={
+            <TextInput.Icon
+              icon={showPassword ? 'eye-off-outline' : 'eye-outline'}
+              onPress={() => setShowPassword(v => !v)}
+            />
+          }
+          style={styles.input}
+          error={!!passwordError}
+          testID="input-password"
+        />
+        {passwordError ? <HelperText type="error" visible>{passwordError}</HelperText> : null}
+      </View>
+
+      {apiError ? (
+        <HelperText type="error" visible style={styles.apiError}>{apiError}</HelperText>
+      ) : null}
+
+      <Button
+        mode="contained"
+        onPress={handleSignIn}
+        loading={loading}
+        disabled={loading}
+        buttonColor={theme.colors.secondary}
+        textColor={theme.colors.onSecondary}
+        contentStyle={styles.btnContent}
+        style={styles.btn}
+        testID="btn-signin"
+      >
+        {t('account.signin')}
+      </Button>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  field: { marginBottom: 12 },
+  input: { backgroundColor: '#fff' },
+  apiError: { marginBottom: 8, fontSize: 14 },
+  btnContent: { paddingVertical: 6 },
+  btn: { borderRadius: 10 },
+});

--- a/mobile/hooks/useBookingFlow.spec.ts
+++ b/mobile/hooks/useBookingFlow.spec.ts
@@ -1,0 +1,321 @@
+import type { Reservation } from '@/services/bookings-cache';
+import type { CheckoutIntent } from '@/services/checkout-store';
+
+import { useBookingFlow, BookingFlowError } from './useBookingFlow';
+
+// react-native pulls in Flow-typed imports + native bridges that don't load in the
+// node test env. Mock the only API we touch.
+jest.mock('react-native', () => ({
+  Alert: { alert: jest.fn() },
+}));
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useCallback: (fn: unknown) => fn,
+}));
+
+const pushMock = jest.fn();
+const replaceMock = jest.fn();
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+}));
+
+const useAuthMock = jest.fn();
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('@/services/checkout-store', () => ({
+  setCheckoutIntent: jest.fn(),
+  getCheckoutIntent: jest.fn(),
+  clearCheckoutIntent: jest.fn(),
+  rebuildIntent: jest.fn(),
+}));
+
+jest.mock('@/services/pending-reservations-store', () => ({
+  setPendingReservation: jest.fn(),
+}));
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { Alert } = require('react-native');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const checkoutStore = require('@/services/checkout-store');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const pendingStore = require('@/services/pending-reservations-store');
+
+const INTENT: CheckoutIntent = {
+  propertyId: 'prop-1',
+  propertyName: 'Hotel A',
+  propertyCity: 'Cancún',
+  propertyThumbnailUrl: null,
+  roomId: 'room-1',
+  roomType: 'Suite',
+  partnerId: 'partner-1',
+  checkIn: '2026-05-15',
+  checkOut: '2026-05-17',
+  guests: 2,
+  estimatedTotalUsd: 800,
+};
+
+function makeReservation(overrides: Partial<Reservation> = {}): Reservation {
+  return {
+    id: 'res-1',
+    propertyId: 'prop-1',
+    roomId: 'room-1',
+    partnerId: 'partner-1',
+    bookerId: 'user-1',
+    checkIn: '2026-05-15',
+    checkOut: '2026-05-17',
+    status: 'held',
+    reason: null,
+    grandTotalUsd: 800,
+    snapshot: {
+      propertyName: 'Hotel A',
+      propertyCity: 'Cancún',
+      propertyNeighborhood: null,
+      propertyCountryCode: 'MX',
+      propertyThumbnailUrl: null,
+      roomType: 'Suite',
+    },
+    holdExpiresAt: null,
+    checkedInAt: null,
+    createdAt: '2026-05-10T00:00:00Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useAuthMock.mockReturnValue({
+    token: 'tok-1',
+    user: { id: 'user-1', email: 'g@example.com', role: 'guest' },
+  });
+});
+
+// ─── book ─────────────────────────────────────────────────────────────────────
+
+describe('book', () => {
+  it('alerts when check-in is missing and does not navigate', () => {
+     
+    const { book } = useBookingFlow();
+
+    book({ ...INTENT, checkIn: '' });
+
+    expect(Alert.alert).toHaveBeenCalledWith('property.selectDatesTitle', 'property.selectDatesMsg');
+    expect(checkoutStore.setCheckoutIntent).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('alerts when check-out is missing', () => {
+     
+    const { book } = useBookingFlow();
+
+    book({ ...INTENT, checkOut: '' });
+
+    expect(Alert.alert).toHaveBeenCalledTimes(1);
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('stashes intent and routes to /sign-in-required when logged out', () => {
+    useAuthMock.mockReturnValue({ token: null, user: null });
+     
+    const { book } = useBookingFlow();
+
+    book(INTENT);
+
+    expect(checkoutStore.setCheckoutIntent).toHaveBeenCalledWith(INTENT);
+    expect(pushMock).toHaveBeenCalledWith('/sign-in-required');
+  });
+
+  it('stashes intent and routes to /booking/checkout when authenticated', () => {
+     
+    const { book } = useBookingFlow();
+
+    book(INTENT);
+
+    expect(checkoutStore.setCheckoutIntent).toHaveBeenCalledWith(INTENT);
+    expect(pushMock).toHaveBeenCalledWith('/booking/checkout');
+  });
+});
+
+// ─── resumeAfterAuth ──────────────────────────────────────────────────────────
+
+describe('resumeAfterAuth', () => {
+  it('replaces to /booking/checkout when an intent is stashed', () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(INTENT);
+     
+    const { resumeAfterAuth } = useBookingFlow();
+
+    resumeAfterAuth();
+
+    expect(replaceMock).toHaveBeenCalledWith('/booking/checkout');
+  });
+
+  it('replaces to /(tabs) when no intent', () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(null);
+     
+    const { resumeAfterAuth } = useBookingFlow();
+
+    resumeAfterAuth();
+
+    expect(replaceMock).toHaveBeenCalledWith('/(tabs)');
+  });
+});
+
+// ─── resumeHeld ───────────────────────────────────────────────────────────────
+
+describe('resumeHeld', () => {
+  it('rebuilds intent and pushes to checkout, returning true', () => {
+    checkoutStore.rebuildIntent.mockReturnValue(INTENT);
+     
+    const { resumeHeld } = useBookingFlow();
+
+    const result = resumeHeld(makeReservation());
+
+    expect(result).toBe(true);
+    expect(checkoutStore.setCheckoutIntent).toHaveBeenCalledWith(INTENT);
+    expect(pushMock).toHaveBeenCalledWith('/booking/checkout');
+  });
+
+  it('returns false when intent cannot be rebuilt', () => {
+    checkoutStore.rebuildIntent.mockReturnValue(null);
+     
+    const { resumeHeld } = useBookingFlow();
+
+    const result = resumeHeld(makeReservation({ snapshot: null }));
+
+    expect(result).toBe(false);
+    expect(checkoutStore.setCheckoutIntent).not.toHaveBeenCalled();
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});
+
+// ─── createReservation ────────────────────────────────────────────────────────
+
+describe('createReservation', () => {
+  const CREATED = {
+    id: 'res-1',
+    grandTotalUsd: 800,
+    holdExpiresAt: '2026-05-10T01:00:00Z',
+    fareBreakdown: {
+      nights: 2,
+      roomRateUsd: 400,
+      subtotalUsd: 800,
+      taxes: [],
+      fees: [],
+      taxTotalUsd: 0,
+      feeTotalUsd: 0,
+      totalUsd: 800,
+    },
+  };
+
+  it('throws BookingFlowError when no intent is stashed', async () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(null);
+     
+    const { createReservation } = useBookingFlow();
+
+    await expect(createReservation()).rejects.toBeInstanceOf(BookingFlowError);
+  });
+
+  it('throws BookingFlowError when not authenticated', async () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(INTENT);
+    useAuthMock.mockReturnValue({ token: null, user: null });
+     
+    const { createReservation } = useBookingFlow();
+
+    await expect(createReservation()).rejects.toBeInstanceOf(BookingFlowError);
+  });
+
+  it('POSTs to /reservations with intent + booker id and returns the created reservation', async () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(INTENT);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(CREATED),
+    } as Response);
+
+     
+    const { createReservation } = useBookingFlow();
+    const result = await createReservation();
+
+    expect(result).toEqual(CREATED);
+    const [, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(init.method).toBe('POST');
+    expect(init.headers.Authorization).toBe('Bearer tok-1');
+    expect(JSON.parse(init.body)).toEqual({
+      propertyId: 'prop-1',
+      roomId: 'room-1',
+      partnerId: 'partner-1',
+      bookerId: 'user-1',
+      checkIn: '2026-05-15',
+      checkOut: '2026-05-17',
+    });
+    expect(pendingStore.setPendingReservation).toHaveBeenCalledWith(true);
+  });
+
+  it('extracts backend message from JSON error body', async () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(INTENT);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      text: () => Promise.resolve(JSON.stringify({ message: 'Room is no longer available' })),
+    } as Response);
+
+     
+    const { createReservation } = useBookingFlow();
+
+    await expect(createReservation()).rejects.toThrow('Room is no longer available');
+  });
+
+  it('falls back to JSON.error field when message is absent', async () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(INTENT);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      text: () => Promise.resolve(JSON.stringify({ error: 'invalid_state' })),
+    } as Response);
+
+     
+    const { createReservation } = useBookingFlow();
+
+    await expect(createReservation()).rejects.toThrow('invalid_state');
+  });
+
+  it('uses raw text body when error response is non-JSON', async () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(INTENT);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      text: () => Promise.resolve('Service unavailable'),
+    } as Response);
+
+     
+    const { createReservation } = useBookingFlow();
+
+    await expect(createReservation()).rejects.toThrow('Service unavailable');
+  });
+
+  it('falls back to translated message when error body is too long', async () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(INTENT);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      text: () => Promise.resolve('x'.repeat(500)),
+    } as Response);
+
+     
+    const { createReservation } = useBookingFlow();
+
+    await expect(createReservation()).rejects.toThrow('checkout.errorHold');
+  });
+});
+
+// ─── BookingFlowError ─────────────────────────────────────────────────────────
+
+describe('BookingFlowError', () => {
+  it('preserves message and optional cause', () => {
+    const cause = new Error('underlying');
+    const err = new BookingFlowError('outer', cause);
+    expect(err.message).toBe('outer');
+    expect(err.cause).toBe(cause);
+    expect(err.name).toBe('BookingFlowError');
+  });
+});

--- a/mobile/hooks/useBookingFlow.ts
+++ b/mobile/hooks/useBookingFlow.ts
@@ -1,0 +1,119 @@
+import { useCallback } from 'react';
+import { Alert } from 'react-native';
+import { useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { useAuth } from '@/hooks/useAuth';
+import {
+  clearCheckoutIntent,
+  getCheckoutIntent,
+  rebuildIntent,
+  setCheckoutIntent,
+  type CheckoutIntent,
+} from '@/services/checkout-store';
+import { setPendingReservation } from '@/services/pending-reservations-store';
+import type { Reservation } from '@/services/bookings-cache';
+
+const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
+
+export interface FareBreakdown {
+  nights: number;
+  roomRateUsd: number;
+  subtotalUsd: number;
+  taxes: { name: string; amountUsd: number }[];
+  fees: { name: string; totalUsd: number }[];
+  taxTotalUsd: number;
+  feeTotalUsd: number;
+  totalUsd: number;
+}
+
+export interface CreatedReservation {
+  id: string;
+  grandTotalUsd: number;
+  holdExpiresAt: string;
+  fareBreakdown: FareBreakdown;
+}
+
+export class BookingFlowError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'BookingFlowError';
+  }
+}
+
+export function useBookingFlow() {
+  const router = useRouter();
+  const { token, user } = useAuth();
+  const { t } = useTranslation();
+
+  const book = useCallback(
+    (intent: CheckoutIntent): void => {
+      if (!intent.checkIn || !intent.checkOut) {
+        Alert.alert(t('property.selectDatesTitle'), t('property.selectDatesMsg'));
+        return;
+      }
+      setCheckoutIntent(intent);
+      router.push(user ? '/booking/checkout' : '/sign-in-required');
+    },
+    [router, user, t],
+  );
+
+  const resumeAfterAuth = useCallback((): void => {
+    const intent = getCheckoutIntent();
+    router.replace(intent ? '/booking/checkout' : '/(tabs)');
+  }, [router]);
+
+  const resumeHeld = useCallback(
+    (reservation: Reservation): boolean => {
+      const intent = rebuildIntent(reservation);
+      if (!intent) return false;
+      setCheckoutIntent(intent);
+      router.push('/booking/checkout');
+      return true;
+    },
+    [router],
+  );
+
+  const createReservation = useCallback(async (): Promise<CreatedReservation> => {
+    const intent = getCheckoutIntent();
+    if (!intent || !token || !user) {
+      throw new BookingFlowError('Missing intent or authentication');
+    }
+
+    const payload = {
+      propertyId: intent.propertyId,
+      roomId: intent.roomId,
+      partnerId: intent.partnerId,
+      bookerId: user.id,
+      checkIn: intent.checkIn,
+      checkOut: intent.checkOut,
+    };
+
+    const res = await fetch(`${API_BASE}/api/booking/reservations`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      let backendMessage = t('checkout.errorHold');
+      try {
+        const errorJson = JSON.parse(errorText);
+        if (typeof errorJson.message === 'string') backendMessage = errorJson.message;
+        else if (typeof errorJson.error === 'string') backendMessage = errorJson.error;
+      } catch {
+        if (errorText && errorText.length < 200) backendMessage = errorText;
+      }
+      throw new BookingFlowError(backendMessage);
+    }
+
+    const data = (await res.json()) as CreatedReservation;
+    setPendingReservation(true);
+    return data;
+  }, [token, user, t]);
+
+  return { book, resumeAfterAuth, resumeHeld, createReservation, clearCheckoutIntent };
+}

--- a/mobile/hooks/usePendingReservation.spec.ts
+++ b/mobile/hooks/usePendingReservation.spec.ts
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { usePendingReservation } from './usePendingReservation';
+import {
+  getPendingReservation,
+  subscribePendingReservation,
+} from '@/services/pending-reservations-store';
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useSyncExternalStore: jest.fn(),
+}));
+
+describe('usePendingReservation', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the value provided by useSyncExternalStore', () => {
+    (React.useSyncExternalStore as jest.Mock).mockReturnValue(true);
+
+     
+    expect(usePendingReservation()).toBe(true);
+  });
+
+  it('wires the store subscribe + getSnapshot through', () => {
+    (React.useSyncExternalStore as jest.Mock).mockReturnValue(false);
+
+     
+    usePendingReservation();
+
+    expect(React.useSyncExternalStore).toHaveBeenCalledWith(
+      subscribePendingReservation,
+      getPendingReservation,
+    );
+  });
+});

--- a/mobile/hooks/usePendingReservation.ts
+++ b/mobile/hooks/usePendingReservation.ts
@@ -1,0 +1,9 @@
+import { useSyncExternalStore } from 'react';
+import {
+  getPendingReservation,
+  subscribePendingReservation,
+} from '@/services/pending-reservations-store';
+
+export function usePendingReservation(): boolean {
+  return useSyncExternalStore(subscribePendingReservation, getPendingReservation);
+}

--- a/mobile/i18n/locales/en.ts
+++ b/mobile/i18n/locales/en.ts
@@ -3,6 +3,7 @@ export default {
     search: 'Search',
     bookings: 'Bookings',
     account: 'Account',
+    pendingReservation: 'Pending reservation payment',
   },
   home: {
     title: 'TravelHub',
@@ -67,6 +68,13 @@ export default {
     errorPasswordRequired: 'Password is required',
     errorInvalidCredentials: 'Invalid email or password',
     errorGeneric: 'Something went wrong. Please try again.',
+  },
+  signInRequired: {
+    title: 'Continue booking',
+    heading: 'To continue your booking',
+    subheading: 'Sign in to reserve your room.',
+    noAccount: "Don't have an account?",
+    createAccount: 'Create account',
   },
   loginMfa: {
     title: 'My Account',

--- a/mobile/i18n/locales/es.ts
+++ b/mobile/i18n/locales/es.ts
@@ -3,6 +3,7 @@ export default {
     search: 'Buscar',
     bookings: 'Reservas',
     account: 'Cuenta',
+    pendingReservation: 'Reserva pendiente de pago',
   },
   home: {
     title: 'TravelHub',
@@ -67,6 +68,13 @@ export default {
     errorPasswordRequired: 'La contraseña es obligatoria',
     errorInvalidCredentials: 'Correo o contraseña incorrectos',
     errorGeneric: 'Ocurrió un error. Intenta de nuevo.',
+  },
+  signInRequired: {
+    title: 'Continuar reserva',
+    heading: 'Para continuar tu reserva',
+    subheading: 'Inicia sesión para reservar tu habitación.',
+    noAccount: '¿No tienes cuenta?',
+    createAccount: 'Crear cuenta',
   },
   loginMfa: {
     title: 'Mi Cuenta',

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -5,8 +5,10 @@ module.exports = {
   transform: {
     '^.+\\.[tj]sx?$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
+  // Accept both flat node_modules and pnpm's .pnpm/<pkg>@<ver>_<deps>/ layout
+  // so specs can import these RN-ecosystem packages without per-file mocks.
   transformIgnorePatterns: [
-    'node_modules/(?!(react-native|react-native-paper|@react-native|@react-native-community|expo|@expo|react-native-safe-area-context)/)',
+    'node_modules/(?!(?:\\.pnpm/)?(react-native|react-native-paper|@react-native|@react-native-community|expo|@expo|react-native-safe-area-context)[@/])',
   ],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
   coverageDirectory: '../coverage/mobile',

--- a/mobile/services/auth-api.spec.ts
+++ b/mobile/services/auth-api.spec.ts
@@ -1,6 +1,6 @@
 import { initiateLogin, verifyMfaCode, AuthApiError } from './auth-api';
 
-const API_BASE = 'http://localhost:3000';
+const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
 
 // ─── fetch mock helpers ────────────────────────────────────────────────────────
 

--- a/mobile/services/pending-reservations-store.spec.ts
+++ b/mobile/services/pending-reservations-store.spec.ts
@@ -1,0 +1,53 @@
+import {
+  getPendingReservation,
+  setPendingReservation,
+  subscribePendingReservation,
+} from './pending-reservations-store';
+
+describe('pending-reservations-store', () => {
+  afterEach(() => {
+    setPendingReservation(false);
+  });
+
+  it('starts as false', () => {
+    expect(getPendingReservation()).toBe(false);
+  });
+
+  it('reflects the most recent value', () => {
+    setPendingReservation(true);
+    expect(getPendingReservation()).toBe(true);
+    setPendingReservation(false);
+    expect(getPendingReservation()).toBe(false);
+  });
+
+  it('notifies subscribers on change', () => {
+    const listener = jest.fn();
+    subscribePendingReservation(listener);
+
+    setPendingReservation(true);
+    setPendingReservation(false);
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not notify if the value is unchanged', () => {
+    setPendingReservation(true);
+    const listener = jest.fn();
+    subscribePendingReservation(listener);
+
+    setPendingReservation(true);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribePendingReservation(listener);
+
+    setPendingReservation(true);
+    unsubscribe();
+    setPendingReservation(false);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mobile/services/pending-reservations-store.ts
+++ b/mobile/services/pending-reservations-store.ts
@@ -1,0 +1,19 @@
+let _hasPending = false;
+const listeners = new Set<() => void>();
+
+export function setPendingReservation(value: boolean): void {
+  if (_hasPending === value) return;
+  _hasPending = value;
+  listeners.forEach((fn) => fn());
+}
+
+export function getPendingReservation(): boolean {
+  return _hasPending;
+}
+
+export function subscribePendingReservation(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}

--- a/mobile/services/search-api.spec.ts
+++ b/mobile/services/search-api.spec.ts
@@ -1,6 +1,6 @@
 import { searchProperties, getFeatured, getCitySuggestions } from './search-api';
 
-const API_BASE = 'http://localhost:3000';
+const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
 
 // ─── fetch mock helpers ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Descripción

Rediseña la experiencia de un usuario sin sesión que intenta reservar en mobile y centraliza la lógica del booking que estaba dispersa por cinco pantallas.

- **Gateway de login dentro del booking** — al tocar "Seleccionar habitación" sin sesión ahora se llega a `/sign-in-required` (form de login inline + botón "Crear cuenta") en vez del tab Cuenta. La intención de checkout queda guardada en memoria; al verificar el MFA el usuario aterriza directo en `/booking/checkout`.
- **Auto-login post-registro** — si hay un `CheckoutIntent` activo, el registro dispara inmediatamente el login + MFA y deja al usuario en el checkout, sin pasar por la pantalla de "cuenta creada".
- **Hook `useBookingFlow`** — concentra las decisiones de ruta (`book`, `resumeAfterAuth`, `resumeHeld`) y la creación del hold (`createReservation`). Replica conceptualmente el hook del frontend, pero mantiene la creación de la reserva en lazy para no generar holds huérfanos cuando el usuario backgroundea la app.
- **Indicador de reserva pendiente** — punto amarillo sobre el ícono de la pestaña Reservas cuando hay una reserva en estado `held`. Se sincroniza desde `trips.tsx` al cargar y desde `checkout.tsx` al crear el hold, así aparece aunque el usuario no haya entrado a Reservas todavía.
- **Frontend** — el enlace "Crear cuenta" en `LoginPage.tsx` usaba `href="#/register"`; ahora navega con `useNavigate({ to: '/register' })`, alineado con el resto del archivo.
- **Tests / config** — specs nuevas para los módulos agregados (`useBookingFlow`, `usePendingReservation`, `pending-reservations-store`); se corrigen 5 specs pre-existentes en `auth-api.spec.ts` y `search-api.spec.ts` que fallaban cuando `mobile/.env` apunta a una IP de LAN; `transformIgnorePatterns` de Jest ahora soporta el layout de pnpm.

## Tipo de cambio
- [x] Nueva funcionalidad
- [x] Refactor
- [x] Infraestructura / configuración

## Cómo probar

1. **Booking sin sesión → login**: log out → buscar → propiedad → fechas → "Seleccionar habitación" → llegar a `/sign-in-required` → iniciar sesión → MFA → caer directo en `/booking/checkout` con la habitación elegida.
2. **Booking sin sesión → crear cuenta**: mismo flujo pero tocando "Crear cuenta" → completar el registro → debería disparar MFA automáticamente y aterrizar en `/booking/checkout`.
3. **Indicador de pendiente**: con una reserva en estado `held`, verificar el punto amarillo sobre la pestaña Reservas desde cualquier otra pestaña; al completar el pago, el punto desaparece tras el siguiente sync.
4. **Retomar pago**: en Reservas, "Completar pago" sobre una reserva `held` debe llevar al checkout reconstruyendo el intent (snapshot completo).
5. **Regresión MFA sin intent**: log in desde el tab Cuenta sin reserva en curso → MFA → aterrizar en `/(tabs)`, no en `/booking/checkout`.

## Issues relacionados
N/A

## Checklist
- [x] El código compila sin errores (`tsc --noEmit` para mobile y frontend)
- [x] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`nx test mobile` → 234/234, 100% lines, 91.4% branches)
- [x] El linter no reporta errores (`nx lint mobile` → 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)