### PR TITLE
feat(push-notifications): notificaciones push via Firebase FCM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,7 +129,7 @@ jobs:
       # - builds & pushes Docker images for all services
       # - creates/updates Cloud Run services
       # - provisions Cloud SQL, Memorystore, Pub/Sub, VPC, Artifact Registry
-      - name: Set SMTP, Stripe and JWT config
+      - name: Set SMTP, Stripe, JWT and Firebase config
         working-directory: pulumi
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
@@ -143,6 +143,9 @@ jobs:
           pulumi config set --stack ${{ env.PULUMI_STACK }} --secret stripeWebhookSecret "${{ secrets.STRIPE_WEBHOOK_SECRET }}"
           pulumi config set --stack ${{ env.PULUMI_STACK }} stripePublishableKey "${{ secrets.STRIPE_PUBLISHABLE_KEY }}"
           pulumi config set --stack ${{ env.PULUMI_STACK }} --secret authJwtSecret "${{ secrets.AUTH_JWT_SECRET }}"
+          pulumi config set --stack ${{ env.PULUMI_STACK }} firebaseProjectId "${{ secrets.FIREBASE_PROJECT_ID }}"
+          pulumi config set --stack ${{ env.PULUMI_STACK }} --secret firebaseClientEmail "${{ secrets.FIREBASE_CLIENT_EMAIL }}"
+          pulumi config set --stack ${{ env.PULUMI_STACK }} --secret firebasePrivateKey "${{ secrets.FIREBASE_PRIVATE_KEY }}"
 
       - name: Deploy infrastructure + services (pulumi up)
         uses: pulumi/actions@v6

--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -23,6 +23,11 @@ const stripeSecretKey       = appConfig.getSecret("stripeSecretKey");
 const stripeWebhookSecret   = appConfig.getSecret("stripeWebhookSecret");
 const stripePublishableKey  = appConfig.get("stripePublishableKey");
 
+// Firebase — required for notification-service push notifications
+const firebaseProjectId    = appConfig.get("firebaseProjectId");
+const firebaseClientEmail  = appConfig.getSecret("firebaseClientEmail");
+const firebasePrivateKey   = appConfig.getSecret("firebasePrivateKey");
+
 // JWT — shared between auth-service (signer) and api-gateway (verifier)
 const authJwtSecret = appConfig.requireSecret("authJwtSecret");
 
@@ -268,6 +273,38 @@ const smtpPassSecret = smtpPass
     })()
   : null;
 
+// ─── Secret Manager — Firebase credentials (notification-service) ────────────
+
+const firebaseClientEmailSecret = firebaseClientEmail
+  ? (() => {
+      const secret = new gcp.secretmanager.Secret("secret-firebase-client-email", {
+        secretId: "travelhub-firebase-client-email",
+        replication: { auto: {} },
+        labels: LABELS,
+      });
+      new gcp.secretmanager.SecretVersion("secret-firebase-client-email-version", {
+        secret: secret.id,
+        secretData: firebaseClientEmail,
+      });
+      return secret;
+    })()
+  : null;
+
+const firebasePrivateKeySecret = firebasePrivateKey
+  ? (() => {
+      const secret = new gcp.secretmanager.Secret("secret-firebase-private-key", {
+        secretId: "travelhub-firebase-private-key",
+        replication: { auto: {} },
+        labels: LABELS,
+      });
+      new gcp.secretmanager.SecretVersion("secret-firebase-private-key-version", {
+        secret: secret.id,
+        secretData: firebasePrivateKey,
+      });
+      return secret;
+    })()
+  : null;
+
 // ─── Secret Manager — Stripe keys (payment-service) ──────────────────────────
 
 const stripeSecretKeySecret = stripeSecretKey
@@ -485,12 +522,25 @@ for (const svc of MICROSERVICES) {
     secretEnvVars["AUTH_JWT_SECRET"]          = { secretId: authJwtSecretSecret.secretId };
   }
 
-  if (svc.name === "notification-service" && smtpHost && smtpUser && smtpPass) {
-    plainEnv["SMTP_HOST"] = smtpHost;
-    plainEnv["SMTP_PORT"] = smtpPort;
-    plainEnv["SMTP_USER"] = smtpUser;
-    plainEnv["SMTP_FROM"] = smtpFrom ?? smtpUser;
-    secretEnvVars["SMTP_PASS"] = { secretId: smtpPassSecret!.secretId };
+  if (svc.name === "notification-service") {
+    plainEnv["MESSAGE_BROKER_TYPE"] = "pubsub";
+    plainEnv["PUBSUB_PROJECT_ID"]   = PROJECT;
+    if (smtpHost && smtpUser && smtpPass) {
+      plainEnv["SMTP_HOST"] = smtpHost;
+      plainEnv["SMTP_PORT"] = smtpPort;
+      plainEnv["SMTP_USER"] = smtpUser;
+      plainEnv["SMTP_FROM"] = smtpFrom ?? smtpUser;
+      secretEnvVars["SMTP_PASS"] = { secretId: smtpPassSecret!.secretId };
+    }
+    if (firebaseProjectId) {
+      plainEnv["FIREBASE_PROJECT_ID"] = firebaseProjectId;
+    }
+    if (firebaseClientEmailSecret) {
+      secretEnvVars["FIREBASE_CLIENT_EMAIL"] = { secretId: firebaseClientEmailSecret.secretId };
+    }
+    if (firebasePrivateKeySecret) {
+      secretEnvVars["FIREBASE_PRIVATE_KEY"] = { secretId: firebasePrivateKeySecret.secretId };
+    }
   }
 
   if (svc.name === "booking-service") {


### PR DESCRIPTION
## Descripción
Implementa notificaciones push en tiempo real para la app móvil usando Firebase Cloud Messaging (FCM). Cuando un pago es procesado por Stripe, el usuario recibe una notificación push en su dispositivo además del correo electrónico ya existente.

**Flujo completo:**
- La app móvil solicita permisos y registra el token FCM vía `POST /notifications/device-tokens`
- Al completarse un pago (webhook de Stripe), `payment-service` llama a `notification-service` con `channel: "push"`
- `notification-service` busca el token FCM del usuario en la base de datos y lo envía vía Firebase Admin SDK
- Los eventos de booking (confirmación, check-out) también disparan pushes

## Tipo de cambio
- [x] Nueva funcionalidad
- [x] Infraestructura / configuración

## Cómo probar
1. Levantar el stack: `docker compose up -d`
2. Registrar un token: `POST http://localhost:3006/notifications/device-tokens` con `{ userId, token, platform }`
3. Enviar push de prueba: `POST http://localhost:3006/notifications/send` con `{ userId, channel: "push", subject: "Test", message: "Hola" }`
4. Verificar logs de `notification-service`: debe aparecer `FCM send failed: invalid FCM token` para tokens falsos, o entrega exitosa con token real
5. En la app móvil: iniciar sesión → los permisos de notificación se solicitan automáticamente → completar un pago → push aparece en el dispositivo

## Issues relacionados
Closes #33

## Checklist
- [x] El código compila sin errores
- [x] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [x] El linter no reporta errores (`pnpm run lint`)