### PR TITLE
fix(deploy): pasar FIREBASE_PRIVATE_KEY via env var para evitar error de newlines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,6 +134,8 @@ jobs:
         env:
           PULUMI_CONFIG_PASSPHRASE: ${{ secrets.PULUMI_CONFIG_PASSPHRASE }}
           GOOGLE_PROJECT: ${{ secrets.GCP_PROJECT_ID }}
+          FIREBASE_CLIENT_EMAIL: ${{ secrets.FIREBASE_CLIENT_EMAIL }}
+          FIREBASE_PRIVATE_KEY: ${{ secrets.FIREBASE_PRIVATE_KEY }}
         run: |
           pulumi config set --stack ${{ env.PULUMI_STACK }} smtpHost "smtp.gmail.com"
           pulumi config set --stack ${{ env.PULUMI_STACK }} smtpUser "${{ secrets.SMTP_USER }}"
@@ -144,8 +146,8 @@ jobs:
           pulumi config set --stack ${{ env.PULUMI_STACK }} stripePublishableKey "${{ secrets.STRIPE_PUBLISHABLE_KEY }}"
           pulumi config set --stack ${{ env.PULUMI_STACK }} --secret authJwtSecret "${{ secrets.AUTH_JWT_SECRET }}"
           pulumi config set --stack ${{ env.PULUMI_STACK }} firebaseProjectId "${{ secrets.FIREBASE_PROJECT_ID }}"
-          pulumi config set --stack ${{ env.PULUMI_STACK }} --secret firebaseClientEmail "${{ secrets.FIREBASE_CLIENT_EMAIL }}"
-          pulumi config set --stack ${{ env.PULUMI_STACK }} --secret firebasePrivateKey "${{ secrets.FIREBASE_PRIVATE_KEY }}"
+          pulumi config set --stack ${{ env.PULUMI_STACK }} --secret firebaseClientEmail "$FIREBASE_CLIENT_EMAIL"
+          pulumi config set --stack ${{ env.PULUMI_STACK }} --secret firebasePrivateKey "$FIREBASE_PRIVATE_KEY"
 
       - name: Deploy infrastructure + services (pulumi up)
         uses: pulumi/actions@v6


### PR DESCRIPTION
## Descripción
Corrige un error en el workflow de despliegue donde `pulumi config set` fallaba con `bad flag syntax` al intentar configurar `FIREBASE_PRIVATE_KEY`. La clave privada RSA contiene saltos de línea que, al expandirse inline con `${{ secrets.FIREBASE_PRIVATE_KEY }}`, rompían el comando de shell antes de ejecutarse.

**Solución:** declarar el secreto en el bloque `env:` del step y referenciarlo como variable de shell (`$FIREBASE_PRIVATE_KEY`) en lugar de expandirlo directamente en el script.

## Tipo de cambio
- [x] Corrección de error

## Cómo probar
1. Mergear este PR
2. El workflow de deploy debe completar el step "Set SMTP, Stripe, JWT and Firebase config" sin errores

## Issues relacionados
Parte de #33

## Checklist
- [x] El código compila sin errores
- [x] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [x] El linter no reporta errores (`pnpm run lint`)