### PR TITLE
fix(deploy): usar -- para que pflag no parsee la clave privada Firebase como flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,7 +145,7 @@ jobs:
           pulumi config set --stack ${{ env.PULUMI_STACK }} --secret authJwtSecret "${{ secrets.AUTH_JWT_SECRET }}"
           pulumi config set --stack ${{ env.PULUMI_STACK }} firebaseProjectId "${{ secrets.FIREBASE_PROJECT_ID }}"
           pulumi config set --stack ${{ env.PULUMI_STACK }} --secret firebaseClientEmail "${{ secrets.FIREBASE_CLIENT_EMAIL }}"
-          pulumi config set --stack ${{ env.PULUMI_STACK }} --secret firebasePrivateKey "${{ secrets.FIREBASE_PRIVATE_KEY }}"
+          pulumi config set --stack ${{ env.PULUMI_STACK }} --secret -- firebasePrivateKey "${{ secrets.FIREBASE_PRIVATE_KEY }}"
 
       - name: Deploy infrastructure + services (pulumi up)
         uses: pulumi/actions@v6


### PR DESCRIPTION
## Descripción
`-----BEGIN PRIVATE KEY-----` empieza con `--`, por lo que pflag (librería de flags de Go usada por Pulumi/cobra) lo interpreta como un flag de línea de comandos sin importar el quoting de bash. El separador `--` le indica a pflag que deje de procesar flags y trate el resto como argumentos posicionales.

## Tipo de cambio
- [x] Corrección de error

## Issues relacionados
Parte de #33

## Checklist
- [x] El código compila sin errores
- [x] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [x] El linter no reporta errores (`pnpm run lint`)