### PR TITLE
fix(auth): corregir flujo post-login y limpiar estado al cerrar sesión

### DIFF
--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import logo from '../assets/logo.png';
 import { useTranslation } from 'react-i18next';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { useAuth } from '../hooks/useAuth';
 import { useTheme } from '@mui/material/styles';
 import LocaleSelector from './LocaleSelector';
@@ -8,7 +8,13 @@ import LocaleSelector from './LocaleSelector';
 export default function Navbar() {
   const { t } = useTranslation();
   const { user, logout } = useAuth();
+  const navigate = useNavigate();
   const theme = useTheme();
+
+  const handleLogout = () => {
+    logout();
+    void navigate({ to: '/' });
+  };
 
   return (
     <header className="bg-white" style={{ borderBottom: `2px solid ${theme.palette.primary.main}` }}>
@@ -30,7 +36,7 @@ export default function Navbar() {
               ) : (
                 <Link to="/trips" className="hover:text-gray-900">{t('nav.myBookings')}</Link>
               )}
-              <button onClick={logout} className="bg-transparent border-0 p-0 text-sm text-gray-700 hover:text-gray-900 cursor-pointer">
+              <button onClick={handleLogout} className="bg-transparent border-0 p-0 text-sm text-gray-700 hover:text-gray-900 cursor-pointer">
                 {t('nav.logout')}
               </button>
             </>

--- a/frontend/src/context/AuthContext.spec.tsx
+++ b/frontend/src/context/AuthContext.spec.tsx
@@ -60,6 +60,16 @@ describe('AuthProvider', () => {
     expect(localStorage.getItem('auth_token')).toBeNull();
   });
 
+  it('logout also clears any pending checkoutIntent from sessionStorage', async () => {
+    sessionStorage.setItem(
+      'checkoutIntent',
+      JSON.stringify({ property: { id: 'p1', name: 'Demo' } }),
+    );
+    render(<AuthProvider><AuthConsumer /></AuthProvider>);
+    await act(async () => { screen.getByRole('button', { name: 'logout' }).click(); });
+    expect(sessionStorage.getItem('checkoutIntent')).toBeNull();
+  });
+
   it('registers an unauthorized handler via authBridge on mount', () => {
     render(<AuthProvider><AuthConsumer /></AuthProvider>);
     expect(mockSetOnUnauthorizedHandler).toHaveBeenCalledWith(expect.any(Function));

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { AuthContext } from './auth-context';
 import type { AuthUser } from './auth-context';
 import { setOnUnauthorizedHandler } from '../utils/authBridge';
+import { clearCheckoutIntent } from '../hooks/useBookingFlow';
 
 type AuthState = {
   token: string | null;
@@ -55,6 +56,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = useCallback(() => {
     localStorage.removeItem('auth_token');
     localStorage.removeItem('auth_user');
+    clearCheckoutIntent();
     setState({ token: null, user: null });
   }, []);
 

--- a/frontend/src/hooks/useBookingFlow.ts
+++ b/frontend/src/hooks/useBookingFlow.ts
@@ -27,6 +27,8 @@ export const consumeCheckoutIntent = (): CheckoutIntent | null => {
   return JSON.parse(raw) as CheckoutIntent;
 };
 
+export const clearCheckoutIntent = (): void => sessionStorage.removeItem(KEY);
+
 /**
  * Module-level promise — survives StrictMode remounts so the reservation
  * request is fired exactly once when the user clicks "Book".

--- a/frontend/src/pages/LoginPage.spec.tsx
+++ b/frontend/src/pages/LoginPage.spec.tsx
@@ -6,14 +6,33 @@ import es from '../i18n/locales/es.json';
 setupTestI18n('es');
 
 const mockNavigate = jest.fn();
+const mockLogin = jest.fn();
+const mockStartCheckoutAfterLogin = jest.fn();
+const mockHasHeldReservation = jest.fn();
 
 jest.mock('@tanstack/react-router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
+jest.mock('../hooks/useAuth', () => ({
+  useAuth: () => ({
+    login: mockLogin,
+  }),
+}));
+
+jest.mock('../hooks/useBookingFlow', () => ({
+  startCheckoutAfterLogin: (...args: unknown[]) => mockStartCheckoutAfterLogin(...args),
+}));
+
+jest.mock('../utils/queries', () => ({
+  hasHeldReservation: (...args: unknown[]) => mockHasHeldReservation(...args),
+}));
+
 describe('LoginPage', () => {
   beforeEach(() => {
     global.fetch = jest.fn();
+    mockStartCheckoutAfterLogin.mockReturnValue(false);
+    mockHasHeldReservation.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -65,15 +84,7 @@ describe('LoginPage', () => {
     expect(await screen.findByText(es.login.errors.invalid_credentials)).toBeInTheDocument();
   });
 
-  it('navigates to MFA page after successful login', async () => {
-    (global.fetch as jest.Mock).mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({ challengeId: 'ch_123' }),
-    });
-
-    render(<LoginPage />);
-
+  const fillAndSubmit = () => {
     fireEvent.change(screen.getByRole('textbox', { name: es.login.email_label }), {
       target: { value: 'TEST@EXAMPLE.COM ' },
     });
@@ -81,6 +92,17 @@ describe('LoginPage', () => {
       target: { value: 'Pass@1234' },
     });
     fireEvent.click(screen.getByRole('button', { name: es.login.submit }));
+  };
+
+  it('navigates to MFA page when mfaRequired is true', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ mfaRequired: true, challengeId: 'ch_123' }),
+    });
+
+    render(<LoginPage />);
+    fillAndSubmit();
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith(
@@ -97,5 +119,79 @@ describe('LoginPage', () => {
       to: '/login/mfa',
       search: { challengeId: 'ch_123' },
     });
+    expect(mockLogin).not.toHaveBeenCalled();
+  });
+
+  it('logs in and navigates to /booking/checkout when a checkout intent was pending', async () => {
+    mockStartCheckoutAfterLogin.mockReturnValue(true);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          mfaRequired: false,
+          accessToken: 'token_123',
+          user: { id: 'u_1', email: 'test@example.com', role: 'guest' },
+        }),
+    });
+
+    render(<LoginPage />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockLogin).toHaveBeenCalledWith('token_123', {
+        id: 'u_1',
+        email: 'test@example.com',
+        role: 'guest',
+      });
+    });
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/booking/checkout' });
+    expect(mockHasHeldReservation).not.toHaveBeenCalled();
+  });
+
+  it('navigates to / when no intent and no held reservation', async () => {
+    mockStartCheckoutAfterLogin.mockReturnValue(false);
+    mockHasHeldReservation.mockResolvedValue(false);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          mfaRequired: false,
+          accessToken: 'token_123',
+          user: { id: 'u_1', email: 'test@example.com', role: 'guest' },
+        }),
+    });
+
+    render(<LoginPage />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockHasHeldReservation).toHaveBeenCalledWith('token_123', 'u_1');
+    });
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/' });
+  });
+
+  it('navigates to /trips when no intent but user has a held reservation', async () => {
+    mockStartCheckoutAfterLogin.mockReturnValue(false);
+    mockHasHeldReservation.mockResolvedValue(true);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          mfaRequired: false,
+          accessToken: 'token_123',
+          user: { id: 'u_1', email: 'test@example.com', role: 'guest' },
+        }),
+    });
+
+    render(<LoginPage />);
+    fillAndSubmit();
+
+    await waitFor(() => {
+      expect(mockHasHeldReservation).toHaveBeenCalledWith('token_123', 'u_1');
+    });
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/trips' });
   });
 });

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -10,10 +10,14 @@ import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOff from '@mui/icons-material/VisibilityOff';
 import { API_BASE } from '../env';
 import LabeledField from '../components/LabeledField';
+import { useAuth } from '../hooks/useAuth';
+import { startCheckoutAfterLogin } from '../hooks/useBookingFlow';
+import { hasHeldReservation } from '../utils/queries';
 
 export default function LoginPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { login } = useAuth();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -58,8 +62,27 @@ export default function LoginPage() {
         return;
       }
 
-      const data = await response.json() as { challengeId: string };
-      navigate({ to: '/login/mfa', search: { challengeId: data.challengeId } });
+      const data = await response.json() as
+        | { mfaRequired: true; challengeId: string }
+        | {
+            mfaRequired: false;
+            accessToken: string;
+            user: { id: string; email: string; role: string; partnerId?: string };
+          };
+
+      if (data.mfaRequired) {
+        navigate({ to: '/login/mfa', search: { challengeId: data.challengeId } });
+        return;
+      }
+
+      login(data.accessToken, data.user);
+      const toCheckout = startCheckoutAfterLogin(data.accessToken, data.user.id);
+      if (toCheckout) {
+        void navigate({ to: '/booking/checkout' });
+        return;
+      }
+      const hasHeld = await hasHeldReservation(data.accessToken, data.user.id);
+      void navigate({ to: hasHeld ? '/trips' : '/' });
     } catch {
       setApiError(t('login.errors.generic'));
     } finally {

--- a/frontend/src/pages/MfaPage.spec.tsx
+++ b/frontend/src/pages/MfaPage.spec.tsx
@@ -30,11 +30,17 @@ jest.mock('../hooks/useBookingFlow', () => ({
   startCheckoutAfterLogin: (...args: unknown[]) => mockStartCheckoutAfterLogin(...args),
 }));
 
+const mockHasHeldReservation = jest.fn();
+jest.mock('../utils/queries', () => ({
+  hasHeldReservation: (...args: unknown[]) => mockHasHeldReservation(...args),
+}));
+
 describe('MfaPage', () => {
   beforeEach(() => {
     mockUseSearch.mockReturnValue({ challengeId: 'ch_123' });
     global.fetch = jest.fn();
     mockStartCheckoutAfterLogin.mockReturnValue(false);
+    mockHasHeldReservation.mockResolvedValue(false);
   });
 
   afterEach(() => {
@@ -195,5 +201,32 @@ describe('MfaPage', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: '/booking/checkout' });
     });
+    expect(mockHasHeldReservation).not.toHaveBeenCalled();
+  });
+
+  it('navigates to /trips when no intent but user has a held reservation', async () => {
+    mockStartCheckoutAfterLogin.mockReturnValue(false);
+    mockHasHeldReservation.mockResolvedValue(true);
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          accessToken: 'token_123',
+          user: { id: 'u_1', email: 'user@example.com', role: 'guest' },
+        }),
+    });
+
+    render(<MfaPage />);
+
+    fireEvent.change(screen.getByLabelText(es.mfa.code_label), {
+      target: { value: '123456' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: es.mfa.submit }));
+
+    await waitFor(() => {
+      expect(mockHasHeldReservation).toHaveBeenCalledWith('token_123', 'u_1');
+    });
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/trips' });
   });
 });

--- a/frontend/src/pages/MfaPage.tsx
+++ b/frontend/src/pages/MfaPage.tsx
@@ -6,6 +6,7 @@ import Alert from '@mui/material/Alert';
 import { API_BASE } from '../env';
 import { useAuth } from '../hooks/useAuth';
 import { startCheckoutAfterLogin } from '../hooks/useBookingFlow';
+import { hasHeldReservation } from '../utils/queries';
 import LabeledField from '../components/LabeledField';
 
 type MfaSearch = { challengeId: string | undefined };
@@ -68,7 +69,12 @@ export default function MfaPage() {
 
       login(data.accessToken, data.user);
       const toCheckout = startCheckoutAfterLogin(data.accessToken, data.user.id);
-      void navigate({ to: toCheckout ? '/booking/checkout' : '/' });
+      if (toCheckout) {
+        void navigate({ to: '/booking/checkout' });
+        return;
+      }
+      const hasHeld = await hasHeldReservation(data.accessToken, data.user.id);
+      void navigate({ to: hasHeld ? '/trips' : '/' });
     } catch {
       setErrorKey('generic');
     } finally {

--- a/frontend/src/utils/queries.ts
+++ b/frontend/src/utils/queries.ts
@@ -238,6 +238,15 @@ export async function fetchMyReservations(token: string, bookerId: string): Prom
   return Array.isArray(data) ? data : (data.reservations ?? []);
 }
 
+export async function hasHeldReservation(token: string, bookerId: string): Promise<boolean> {
+  try {
+    const reservations = await fetchMyReservations(token, bookerId);
+    return reservations.some((r) => r.status === 'held');
+  } catch {
+    return false;
+  }
+}
+
 export interface CancelReservationOutcome {
   status: ReservationStatus;
   refund: {

--- a/mobile/app/(auth)/login-mfa.tsx
+++ b/mobile/app/(auth)/login-mfa.tsx
@@ -26,7 +26,7 @@ export default function LoginMfaScreen() {
     setLoading(true);
     try {
       await auth.verifyMfa(challengeId, code.trim());
-      resumeAfterAuth();
+      await resumeAfterAuth();
     } catch (err) {
       if (err instanceof AuthApiError && err.status === 401) {
         setApiError(t('loginMfa.errorInvalidCode'));

--- a/mobile/app/(auth)/register.tsx
+++ b/mobile/app/(auth)/register.tsx
@@ -79,7 +79,7 @@ export default function RegisterScreen() {
               `/login-mfa?challengeId=${result.challengeId}&email=${encodeURIComponent(result.email)}`,
             );
           } else {
-            resumeAfterAuth();
+            await resumeAfterAuth();
           }
           return;
         } catch {

--- a/mobile/components/auth/login-form.tsx
+++ b/mobile/components/auth/login-form.tsx
@@ -35,7 +35,7 @@ export function LoginForm() {
       if (result.mfaRequired) {
         router.push(`/login-mfa?challengeId=${result.challengeId}&email=${encodeURIComponent(result.email)}`);
       } else {
-        resumeAfterAuth();
+        await resumeAfterAuth();
       }
     } catch (err) {
       if (err instanceof AuthApiError && err.status === 401) {

--- a/mobile/hooks/useAuth.spec.ts
+++ b/mobile/hooks/useAuth.spec.ts
@@ -19,6 +19,10 @@ jest.mock('@/context/AuthContext', () => ({
   USER_KEY: '@auth_user',
 }));
 
+jest.mock('@/services/checkout-store', () => ({
+  clearCheckoutIntent: jest.fn(),
+}));
+
 /* Mock react so we can control useContext */
 const originalUseContext = React.useContext;
 
@@ -30,6 +34,8 @@ afterEach(() => {
 const AsyncStorage = require('@react-native-async-storage/async-storage');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { initiateLogin, verifyMfaCode } = require('@/services/auth-api');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { clearCheckoutIntent } = require('@/services/checkout-store');
 
 function makeCtx(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
   return {
@@ -131,7 +137,7 @@ describe('useAuth', () => {
   });
 
   describe('logout', () => {
-    it('removes token + user from AsyncStorage and clears context', async () => {
+    it('removes token + user from AsyncStorage, clears checkout intent, and clears context', async () => {
       const ctx = makeCtx({ token: 'existing-token' });
       jest.spyOn(React, 'useContext').mockReturnValue(ctx);
 
@@ -140,6 +146,7 @@ describe('useAuth', () => {
 
       expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@auth_token');
       expect(AsyncStorage.removeItem).toHaveBeenCalledWith('@auth_user');
+      expect(clearCheckoutIntent).toHaveBeenCalled();
       expect(ctx.setToken).toHaveBeenCalledWith(null);
       expect(ctx.setUser).toHaveBeenCalledWith(null);
     });

--- a/mobile/hooks/useAuth.ts
+++ b/mobile/hooks/useAuth.ts
@@ -4,6 +4,7 @@ import { AuthContext } from '@/context/auth-context';
 import type { SignInResult } from '@/context/auth-context';
 import { TOKEN_KEY, USER_KEY } from '@/context/AuthContext';
 import { initiateLogin, verifyMfaCode } from '@/services/auth-api';
+import { clearCheckoutIntent } from '@/services/checkout-store';
 
 export function useAuth() {
   const ctx = useContext(AuthContext);
@@ -38,6 +39,7 @@ export function useAuth() {
       AsyncStorage.removeItem(TOKEN_KEY),
       AsyncStorage.removeItem(USER_KEY),
     ]);
+    clearCheckoutIntent();
     ctx.setToken(null);
     ctx.setUser(null);
   };

--- a/mobile/hooks/useBookingFlow.spec.ts
+++ b/mobile/hooks/useBookingFlow.spec.ts
@@ -39,12 +39,31 @@ jest.mock('@/services/checkout-store', () => ({
 jest.mock('@/services/pending-reservations-store', () => ({
   setPendingReservation: jest.fn(),
 }));
+
+jest.mock('@/services/bookings-cache', () => ({
+  hasHeldReservation: jest.fn(),
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: { getItem: jest.fn() },
+}));
+
+jest.mock('@/context/AuthContext', () => ({
+  TOKEN_KEY: '@auth_token',
+  USER_KEY: '@auth_user',
+}));
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const { Alert } = require('react-native');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const checkoutStore = require('@/services/checkout-store');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const pendingStore = require('@/services/pending-reservations-store');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const bookingsCache = require('@/services/bookings-cache');
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const AsyncStorage = require('@react-native-async-storage/async-storage').default;
 
 const INTENT: CheckoutIntent = {
   propertyId: 'prop-1',
@@ -144,23 +163,63 @@ describe('book', () => {
 // ─── resumeAfterAuth ──────────────────────────────────────────────────────────
 
 describe('resumeAfterAuth', () => {
-  it('replaces to /booking/checkout when an intent is stashed', () => {
+  it('replaces to /booking/checkout when an intent is stashed', async () => {
     checkoutStore.getCheckoutIntent.mockReturnValue(INTENT);
-     
+
     const { resumeAfterAuth } = useBookingFlow();
 
-    resumeAfterAuth();
+    await resumeAfterAuth();
 
     expect(replaceMock).toHaveBeenCalledWith('/booking/checkout');
+    expect(bookingsCache.hasHeldReservation).not.toHaveBeenCalled();
   });
 
-  it('replaces to /(tabs) when no intent', () => {
+  it('replaces to /(tabs) when no intent and no held reservations', async () => {
     checkoutStore.getCheckoutIntent.mockReturnValue(null);
-     
+    AsyncStorage.getItem.mockImplementation((key: string) =>
+      Promise.resolve(
+        key === '@auth_token'
+          ? 'tok-1'
+          : JSON.stringify({ id: 'user-1', email: 'g@example.com', role: 'guest' }),
+      ),
+    );
+    bookingsCache.hasHeldReservation.mockResolvedValue(false);
+
     const { resumeAfterAuth } = useBookingFlow();
 
-    resumeAfterAuth();
+    await resumeAfterAuth();
 
+    expect(bookingsCache.hasHeldReservation).toHaveBeenCalledWith('tok-1', 'user-1');
+    expect(replaceMock).toHaveBeenCalledWith('/(tabs)');
+  });
+
+  it('replaces to /(tabs)/trips when no intent but user has a held reservation', async () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(null);
+    AsyncStorage.getItem.mockImplementation((key: string) =>
+      Promise.resolve(
+        key === '@auth_token'
+          ? 'tok-1'
+          : JSON.stringify({ id: 'user-1', email: 'g@example.com', role: 'guest' }),
+      ),
+    );
+    bookingsCache.hasHeldReservation.mockResolvedValue(true);
+
+    const { resumeAfterAuth } = useBookingFlow();
+
+    await resumeAfterAuth();
+
+    expect(replaceMock).toHaveBeenCalledWith('/(tabs)/trips');
+  });
+
+  it('falls back to /(tabs) when stored credentials are missing', async () => {
+    checkoutStore.getCheckoutIntent.mockReturnValue(null);
+    AsyncStorage.getItem.mockResolvedValue(null);
+
+    const { resumeAfterAuth } = useBookingFlow();
+
+    await resumeAfterAuth();
+
+    expect(bookingsCache.hasHeldReservation).not.toHaveBeenCalled();
     expect(replaceMock).toHaveBeenCalledWith('/(tabs)');
   });
 });

--- a/mobile/hooks/useBookingFlow.ts
+++ b/mobile/hooks/useBookingFlow.ts
@@ -2,7 +2,10 @@ import { useCallback } from 'react';
 import { Alert } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useAuth } from '@/hooks/useAuth';
+import { TOKEN_KEY, USER_KEY } from '@/context/AuthContext';
+import type { AuthUser } from '@/context/auth-context';
 import {
   clearCheckoutIntent,
   getCheckoutIntent,
@@ -11,7 +14,7 @@ import {
   type CheckoutIntent,
 } from '@/services/checkout-store';
 import { setPendingReservation } from '@/services/pending-reservations-store';
-import type { Reservation } from '@/services/bookings-cache';
+import { hasHeldReservation, type Reservation } from '@/services/bookings-cache';
 
 const API_BASE = process.env.EXPO_PUBLIC_API_URL ?? 'http://localhost:3000';
 
@@ -57,9 +60,25 @@ export function useBookingFlow() {
     [router, user, t],
   );
 
-  const resumeAfterAuth = useCallback((): void => {
+  const resumeAfterAuth = useCallback(async (): Promise<void> => {
     const intent = getCheckoutIntent();
-    router.replace(intent ? '/booking/checkout' : '/(tabs)');
+    if (intent) {
+      router.replace('/booking/checkout');
+      return;
+    }
+    // Read directly from AsyncStorage — react context state may not have
+    // settled yet in the tick right after login()/verifyMfa() resolves.
+    const [freshToken, rawUser] = await Promise.all([
+      AsyncStorage.getItem(TOKEN_KEY),
+      AsyncStorage.getItem(USER_KEY),
+    ]);
+    if (!freshToken || !rawUser) {
+      router.replace('/(tabs)');
+      return;
+    }
+    const freshUser = JSON.parse(rawUser) as AuthUser;
+    const hasHeld = await hasHeldReservation(freshToken, freshUser.id);
+    router.replace(hasHeld ? '/(tabs)/trips' : '/(tabs)');
   }, [router]);
 
   const resumeHeld = useCallback(

--- a/mobile/services/bookings-cache.ts
+++ b/mobile/services/bookings-cache.ts
@@ -70,6 +70,15 @@ export async function syncReservations(token: string, userId: string): Promise<R
   return reservations;
 }
 
+export async function hasHeldReservation(token: string, userId: string): Promise<boolean> {
+  try {
+    const reservations = await fetchReservations(token, userId);
+    return reservations.some((r) => r.status === 'held');
+  } catch {
+    return false;
+  }
+}
+
 export class CheckInError extends Error {
   constructor(public readonly status: number) {
     super(`Check-in failed: ${status}`);


### PR DESCRIPTION
## Descripción

Corrige varios problemas del flujo de autenticación en frontend y mobile.

**1. Login sin MFA quedaba bloqueado en `/login`** — `LoginPage` ignoraba la rama `mfaRequired: false` y siempre navegaba a `/login/mfa` con `challengeId` undefined, rebotando de regreso. Ahora discrimina la respuesta y, si la cuenta no exige MFA, ejecuta `login()` directamente.

**2. `checkoutIntent` permanecía tras cerrar sesión y secuestraba el siguiente login** — el intent en `sessionStorage` (web) y en memoria (mobile) nunca se limpiaba al hacer logout, por lo que un login posterior disparaba un `POST /reservations` y un `held` no solicitado sobre la selección anterior. Ahora `logout()` limpia el intent (web y mobile).

**3. Tras autenticarse no se contemplaba una reserva `held` existente** — añadimos `hasHeldReservation()` (frontend `utils/queries.ts`, mobile `services/bookings-cache.ts`) y, si no hay intent activo pero el usuario tiene una reserva `held` en BD, redirigimos a `/trips` (web) o `/(tabs)/trips` (mobile) para que pueda retomar o cancelar. Sin held va al home.

**4. Cerrar sesión desde `/booking/checkout` (u otras páginas protegidas) dejaba la pantalla en blanco** — `Navbar` solo llamaba a `logout()` y nunca navegaba. Ahora hace `navigate({ to: '/' })` tras el logout, evitando que páginas protegidas queden con estado a medias.

### Modelo

`checkoutIntent` es **caché de sesión** para datos de selección (habitación/propiedad). La verdad persistida es la reserva `held` en la BD. El intent debe morir cuando ya no sirve: al consumirse en checkout, o al cerrar sesión. No requiere señales por URL (`next=`) ni TTL.

## Tipo de cambio
- [x] Corrección de error

## Cómo probar

Levantar el stack con `pnpm start` y validar en **web (http://localhost:4200) y mobile (`nx run-ios mobile`)**:

1. **Regresión del intent obsoleto (bug principal)**: Tab 1 — login como usuario A, click Book sobre Propiedad X, logout, login como usuario B. Esperado: `/` o `/trips` según held, **no** el checkout de X.
2. **Login plano sin held**: navbar → Sign in con usuario sin reservas held. Esperado: `/`.
3. **Login plano con held**: sembrar una reserva held (`POST /api/booking/reservations` o click Book y abandonar). Login por navbar. Esperado: `/trips`.
4. **Book → login → MFA → checkout**: logout, click Book, login con usuario MFA, código. Esperado: `/booking/checkout`.
5. **Book → register → MFA → checkout**: logout, click Book, link a Register, registrar, MFA. Esperado: `/booking/checkout`.
6. **Logout desde checkout**: login, navegar a `/booking/checkout`, click Logout. Esperado: redirección a `/` (no pantalla en blanco).

## Issues relacionados
N/A

## Checklist
- [x] El código compila sin errores
- [x] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test` — frontend 669/669, mobile 237/237)
- [x] El linter no reporta errores (`pnpm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)