### PR TITLE
chore(ci): cachear Gradle + arreglar publicación de artefactos y ANR en e2e-mobile

### DIFF
--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -45,6 +45,16 @@ jobs:
           distribution: temurin
           java-version: '17'
 
+      - name: Cache Gradle (user-level)
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('mobile/android/**/*.gradle*', 'mobile/android/gradle/wrapper/gradle-wrapper.properties', 'mobile/package.json', 'pnpm-lock.yaml') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-
+
       - name: Setup Expo + EAS CLI
         uses: expo/expo-github-action@v8
         with:

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -122,6 +122,29 @@ jobs:
             adb install -r artifacts/app.apk
             pnpm run e2e:mobile:report
 
+      # TODO(revertir): paso de diagnóstico temporal. Una vez confirmemos dónde
+      # Maestro está escribiendo screenshots/commands JSON en CI, eliminar este
+      # paso y ajustar el upload-artifact correspondiente.
+      - name: Diagnose Maestro output paths
+        if: always()
+        run: |
+          echo "=== pwd ==="
+          pwd
+          echo "=== ls e2e/mobile/.artifacts ==="
+          ls -laR e2e/mobile/.artifacts/ 2>&1 || echo "(missing)"
+          echo "=== ls e2e/mobile/reports ==="
+          ls -la e2e/mobile/reports/ 2>&1 || echo "(missing)"
+          echo "=== find workspace for maestro artifacts ==="
+          find "$GITHUB_WORKSPACE" \
+            \( -name "screenshot-*.png" -o -name "commands-*.json" -o -name "maestro.log" -o -name "report.html" \) \
+            2>/dev/null | head -200
+          echo "=== ls ~/.maestro ==="
+          ls -la "$HOME/.maestro" 2>&1 || echo "(missing)"
+          echo "=== find ~/.maestro for artifacts ==="
+          find "$HOME/.maestro" -type f \
+            \( -name "screenshot-*.png" -o -name "commands-*.json" -o -name "maestro.log" \) \
+            2>/dev/null | head -200
+
       - name: Upload Maestro HTML report
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -120,6 +120,14 @@ jobs:
           disable-animations: true
           script: |
             adb install -r artifacts/app.apk
+            # Pequeña pausa para que el launcher (Pixel Launcher) termine de
+            # estabilizarse tras el boot del emulador antes de lanzar la app
+            # — evita la carrera con el ANR "Pixel Launcher isn't responding".
+            sleep 5
+            # Dismiss any pending system dialog (ANR/permission) que pudiera
+            # estar en foreground; KEYCODE_BACK es no-op si no hay diálogo.
+            adb shell input keyevent KEYCODE_BACK || true
+            adb shell input keyevent KEYCODE_HOME || true
             pnpm run e2e:mobile:report
 
       - name: Upload Maestro HTML report

--- a/.github/workflows/e2e-mobile.yml
+++ b/.github/workflows/e2e-mobile.yml
@@ -122,29 +122,6 @@ jobs:
             adb install -r artifacts/app.apk
             pnpm run e2e:mobile:report
 
-      # TODO(revertir): paso de diagnóstico temporal. Una vez confirmemos dónde
-      # Maestro está escribiendo screenshots/commands JSON en CI, eliminar este
-      # paso y ajustar el upload-artifact correspondiente.
-      - name: Diagnose Maestro output paths
-        if: always()
-        run: |
-          echo "=== pwd ==="
-          pwd
-          echo "=== ls e2e/mobile/.artifacts ==="
-          ls -laR e2e/mobile/.artifacts/ 2>&1 || echo "(missing)"
-          echo "=== ls e2e/mobile/reports ==="
-          ls -la e2e/mobile/reports/ 2>&1 || echo "(missing)"
-          echo "=== find workspace for maestro artifacts ==="
-          find "$GITHUB_WORKSPACE" \
-            \( -name "screenshot-*.png" -o -name "commands-*.json" -o -name "maestro.log" -o -name "report.html" \) \
-            2>/dev/null | head -200
-          echo "=== ls ~/.maestro ==="
-          ls -la "$HOME/.maestro" 2>&1 || echo "(missing)"
-          echo "=== find ~/.maestro for artifacts ==="
-          find "$HOME/.maestro" -type f \
-            \( -name "screenshot-*.png" -o -name "commands-*.json" -o -name "maestro.log" \) \
-            2>/dev/null | head -200
-
       - name: Upload Maestro HTML report
         if: always()
         uses: actions/upload-artifact@v4
@@ -154,6 +131,9 @@ jobs:
           retention-days: 14
           if-no-files-found: warn
 
+      # `e2e/mobile/.artifacts/` empieza con punto, por lo que upload-artifact@v4
+      # lo descarta por defecto (include-hidden-files: false). Lo habilitamos
+      # explícitamente para que screenshots y commands JSON sí se publiquen.
       - name: Upload Maestro per-flow artifacts (screenshots / video / hierarchy)
         if: always()
         uses: actions/upload-artifact@v4
@@ -162,3 +142,4 @@ jobs:
           path: e2e/mobile/.artifacts/
           retention-days: 7
           if-no-files-found: ignore
+          include-hidden-files: true

--- a/e2e/mobile/flows/booking-book-then-login.yaml
+++ b/e2e/mobile/flows/booking-book-then-login.yaml
@@ -15,6 +15,8 @@ env:
 - launchApp:
     clearState: true
 
+- runFlow: "../utils/dismiss-system-dialogs.yaml"
+
 - assertVisible:
     id: "input-city"
 

--- a/e2e/mobile/flows/booking-login-then-book.yaml
+++ b/e2e/mobile/flows/booking-login-then-book.yaml
@@ -15,6 +15,8 @@ env:
 - launchApp:
     clearState: true
 
+- runFlow: "../utils/dismiss-system-dialogs.yaml"
+
 - assertVisible:
     id: "input-city"
 

--- a/e2e/mobile/flows/login.yaml
+++ b/e2e/mobile/flows/login.yaml
@@ -10,6 +10,8 @@ env:
 - launchApp:
     clearState: true
 
+- runFlow: "../utils/dismiss-system-dialogs.yaml"
+
 - assertVisible:
     id: "input-city"
 

--- a/e2e/mobile/flows/register.yaml
+++ b/e2e/mobile/flows/register.yaml
@@ -13,6 +13,8 @@ env:
 - launchApp:
     clearState: true
 
+- runFlow: "../utils/dismiss-system-dialogs.yaml"
+
 - assertVisible:
     id: "input-city"
 

--- a/e2e/mobile/utils/dismiss-system-dialogs.yaml
+++ b/e2e/mobile/utils/dismiss-system-dialogs.yaml
@@ -1,0 +1,11 @@
+# Dismisses Android system dialogs that race with test startup on the CI
+# emulator (most notably "Pixel Launcher isn't responding" ANR popups).
+# All taps are optional so this is a no-op when no dialog is present.
+appId: com.travelhub.mobile
+---
+- tapOn:
+    text: "Wait"
+    optional: true
+- tapOn:
+    text: "Close app"
+    optional: true

--- a/e2e/mobile/utils/pay-stripe-test-card.yaml
+++ b/e2e/mobile/utils/pay-stripe-test-card.yaml
@@ -70,9 +70,18 @@ appId: com.travelhub.mobile
 # Dismiss the native numeric keyboard so the Pay button is reachable.
 - hideKeyboard
 
-# Stripe's submit button label includes the amount: "Pay $123.45".
+# Stripe's submit button label includes the amount (e.g. "Pay $123.45"). The
+# whitespace between "Pay" and the currency symbol can be a non-breaking
+# space ( ) in some locale renderings, so we use `.*` between "Pay"
+# and "\$" instead of a literal space. Wait until the button is actually
+# visible — after hideKeyboard, the relayout pass takes a moment before the
+# button settles into the visible area.
+- extendedWaitUntil:
+    visible:
+      text: "Pay.*\\$.*"
+    timeout: 10000
 - tapOn:
-    text: "Pay \\$.*"
+    text: "Pay.*\\$.*"
 
 # We don't wait here — the confirmation screen does its own polling
 # (usePaymentPolling: 60 s max). Callers should follow this flow with an

--- a/e2e/mobile/utils/pay-stripe-test-card.yaml
+++ b/e2e/mobile/utils/pay-stripe-test-card.yaml
@@ -16,6 +16,21 @@ appId: com.travelhub.mobile
 - waitForAnimationToEnd:
     timeout: 8000
 
+# Newer Stripe PaymentSheet variants open on a payment-method selector
+# (Link / Card / Cash App Pay / Amazon Pay rows) instead of the card form.
+# We detect that screen by the presence of "Cash App Pay" — unique to the
+# selector — and tap "Card" to expand the card form. When the sheet opens
+# directly on the card form, this runFlow is a no-op.
+- runFlow:
+    when:
+      visible:
+        text: "Cash App Pay"
+    commands:
+      - tapOn:
+          text: "Card"
+      - waitForAnimationToEnd:
+          timeout: 3000
+
 # Card number
 - tapOn:
     text: "Card number"

--- a/e2e/mobile/utils/pay-stripe-test-card.yaml
+++ b/e2e/mobile/utils/pay-stripe-test-card.yaml
@@ -70,18 +70,18 @@ appId: com.travelhub.mobile
 # Dismiss the native numeric keyboard so the Pay button is reachable.
 - hideKeyboard
 
-# Stripe's submit button label includes the amount (e.g. "Pay $123.45"). The
-# whitespace between "Pay" and the currency symbol can be a non-breaking
-# space ( ) in some locale renderings, so we use `.*` between "Pay"
-# and "\$" instead of a literal space. Wait until the button is actually
-# visible — after hideKeyboard, the relayout pass takes a moment before the
-# button settles into the visible area.
+# Stripe's submit button merges its semantics: the visible "Pay $X" label is
+# NOT exposed as a `text` or `content-desc` node in the accessibility tree
+# (both attributes are empty on the button view, confirmed via
+# `adb shell uiautomator dump`). We target it instead by the stable
+# resource-id `com.travelhub.mobile:id/primary_button` published by the
+# Stripe Android SDK — language- and currency-independent.
 - extendedWaitUntil:
     visible:
-      text: "Pay.*\\$.*"
+      id: "primary_button"
     timeout: 10000
 - tapOn:
-    text: "Pay.*\\$.*"
+    id: "primary_button"
 
 # We don't wait here — the confirmation screen does its own polling
 # (usePaymentPolling: 60 s max). Callers should follow this flow with an

--- a/e2e/mobile/utils/pay-stripe-test-card.yaml
+++ b/e2e/mobile/utils/pay-stripe-test-card.yaml
@@ -52,25 +52,23 @@ appId: com.travelhub.mobile
     optional: true
 - inputText: "123"
 
-# Postal / ZIP is only shown for some country/card combos. We do NOT type
-# unconditionally: when the field is absent, `inputText` would append to
-# whichever input is still focused (typically CVC) and silently corrupt it.
-# Maestro 1.x+ supports a `runFlow` with a `when.visible` guard for this.
+# Postal / ZIP is only shown for some country/card combos (e.g. United States
+# in the Stripe test sheet renders "ZIP Code"). We do NOT type unconditionally:
+# when the field is absent, `inputText` would append to whichever input is
+# still focused (typically CVC) and silently corrupt it. The regex is
+# unanchored on both sides because Maestro matches `text:` as a full-string
+# regex — "ZIP Code" must be caught by ".*ZIP.*", not by "ZIP".
 - runFlow:
     when:
       visible:
-        text: "ZIP|Postal code"
+        text: ".*ZIP.*|.*Postal.*"
     commands:
       - tapOn:
-          text: "ZIP|Postal code"
+          text: ".*ZIP.*|.*Postal.*"
       - inputText: "12345"
 
-# Dismiss the native numeric keyboard so the Pay button is reachable. The
-# Stripe sheet's "Billing address" header is a static label that isn't tied to
-# an input, so tapping it removes focus from CVC/ZIP and the keyboard closes.
-- tapOn:
-    text: "Billing address"
-    optional: true
+# Dismiss the native numeric keyboard so the Pay button is reachable.
+- hideKeyboard
 
 # Stripe's submit button label includes the amount: "Pay $123.45".
 - tapOn:


### PR DESCRIPTION
## Descripción
Cuatro cambios sobre el workflow `e2e-mobile.yml` y los flujos de Maestro, motivados por una corrida de E2E que no publicaba screenshots y donde los flujos fallaban en el emulador de CI.

### 1. Caché de Gradle a nivel de usuario
Añade `actions/cache@v4` que persiste `~/.gradle/caches` y `~/.gradle/wrapper` entre runs. Reduce el tiempo de build del APK Android al evitar descargas repetidas de módulos Gradle y artefactos del compilador de Kotlin en hits cálidos. La clave del caché combina `mobile/android/**/*.gradle*`, el wrapper, `mobile/package.json` (entradas de autolinking de Expo) y `pnpm-lock.yaml`; `restore-keys` permite hits parciales. Solo se cachea a nivel de usuario porque `eas build --local` puede copiar el proyecto a un directorio temporal, dejando inservible cualquier caché a nivel de proyecto.

### 2. Publicar artefactos por flujo (`include-hidden-files: true`)
`e2e/mobile/.artifacts/` empieza con punto, así que `actions/upload-artifact@v4` lo trataba como ruta oculta y descartaba todo su contenido por defecto. El log reportaba `No files were found with the provided path` aunque Maestro sí escribía screenshots y `commands-*.json` ahí. Se habilita `include-hidden-files: true` en el paso de upload de artefactos por flujo.

### 3. Mitigar ANR del Pixel Launcher
El emulador del runner suele mostrar un diálogo del sistema `Pixel Launcher isn't responding` justo después del boot. Aunque la app TravelHub se renderiza correctamente detrás, el diálogo tiene el foco y Maestro consulta el view hierarchy de la ventana enfocada, por lo que `assertVisible: id: input-city` falla. Doble mitigación:
- Nuevo subflujo `e2e/mobile/utils/dismiss-system-dialogs.yaml` con taps opcionales sobre `Wait` y `Close app`. Se invoca vía `runFlow` después de `launchApp` en los 4 flujos activos (login, register, las dos variantes de booking). No-op cuando no hay diálogo.
- Antes de invocar Maestro en el workflow, una pausa de 5s para que el launcher se estabilice y dos keyevents (`KEYCODE_BACK`, `KEYCODE_HOME`) por ADB para descartar cualquier diálogo pendiente.

### 4. Manejar selector de método de pago en Stripe PaymentSheet
Algunas variantes del Stripe PaymentSheet (visible en Pixel 6 API 34 de CI) abren primero una pantalla de selector con filas `Link / Card / Cash App Pay / Amazon Pay` en lugar del formulario de tarjeta. El flujo asumía que el formulario ya estaba expandido, por lo que `inputText` caía en un input sin foco y el botón `Pay $...` quedaba deshabilitado. Se añade un `runFlow` condicional en `e2e/mobile/utils/pay-stripe-test-card.yaml` con `when.visible: "Cash App Pay"` (texto único del selector) que toca `Card` para expandir el formulario antes de llenar los campos. En variantes que abren directamente en el formulario, el bloque es un no-op.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [x] Infraestructura / configuración

## Cómo probar
- [ ] Disparar `E2E Mobile (Maestro)` desde GitHub Actions (`workflow_dispatch`). La primera corrida será fría y sembrará el caché de Gradle.
- [ ] Re-ejecutar y verificar en los logs del paso `Cache Gradle (user-level)` que aparece `Cache hit` y que el build del APK termina notablemente más rápido.
- [ ] Comprobar que el artefacto `maestro-artifacts-<run_id>` ya no está vacío (debería contener `<timestamp>/commands-*.json` y, si hay fallos, `screenshot-❌-*.png`).
- [ ] Confirmar que los flujos `login` y `register` ya no fallan por el ANR del Pixel Launcher.
- [ ] Confirmar que los flujos `booking-*` avanzan correctamente por el PaymentSheet de Stripe en el emulador de CI.

## Issues relacionados
N/A

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [x] El linter no reporta errores (`pnpm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)