### PR TITLE
chore(auth-seed): desactivar MFA para todos los usuarios semilla

### DIFF
--- a/services/auth-service/scripts/seed.ts
+++ b/services/auth-service/scripts/seed.ts
@@ -100,7 +100,7 @@ async function seed() {
         last_name: u.lastName,
         phone: null,
         partner_id: u.partnerId,
-        mfa_required: u.mfaRequired ?? true,
+        mfa_required: u.mfaRequired ?? false,
       })),
     )
     .execute();


### PR DESCRIPTION
## Descripción

Cambia el default de `mfa_required` en el seed de auth-service de `true` a `false`. Los 5 usuarios semilla (`admin`, `partner`, `partner2`, `guest`, `e2e`) ahora inician sesión sin pasar por el reto OTP.

Motivación: en local/CI no hay un correo cableado para entregar el OTP, así que el reto bloquea cualquier flujo automatizado o demo manual con los usuarios semilla. El usuario `e2e@travelhub.com` ya tenía el bypass explícito; este cambio extiende el mismo trato al resto del set semilla.

| Email | Role | MFA |
|---|---|---|
| admin@travelhub.com | admin | off |
| partner@travelhub.com | partner | off |
| partner2@travelhub.com | partner | off |
| guest@travelhub.com | guest | off |
| e2e@travelhub.com | guest | off |

El comportamiento de producción no cambia: los usuarios registrados vía `/api/auth/register` siguen creando challenges normalmente, y el helper `registerInternal` (usado por el registro de partner) tampoco se toca.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [ ] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [x] Infraestructura / configuración

## Cómo probar

```
pnpm exec nx run auth-service:seed --outputStyle=static
# luego, contra cualquier usuario semilla:
curl -fsS http://localhost:3000/api/auth/login \
  -H 'Content-Type: application/json' \
  -d '{"email":"partner@travelhub.com","password":"Partner1234!"}' | jq .
# Esperado: { mfaRequired: false, accessToken: "...", user: {...} }
```

## Issues relacionados
N/A

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test --projects=auth-service` — el spec de seed no aplica)
- [x] El linter no reporta errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)