### PR TITLE
feat(docs):  Update docs for GCP infra and add full Spanish documentation

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -6,16 +6,106 @@ All production deployments run through **GitHub Actions**. You do not run `pulum
 
 ## GitHub Secrets Required
 
-Go to **Settings → Secrets and variables → Actions → New repository secret** and add all four:
+Go to **Settings → Secrets and variables → Actions → New repository secret** and add the values used by the deployment and build workflows. The workflows and Pulumi expect the following secrets and configuration keys:
 
-| Secret | Required by | Value |
+| Secret | Required by | Notes |
 |---|---|---|
-| `GCP_SA_KEY` | deploy, destroy, seed | Full JSON key of the deploy service account — see "Create the deploy service account" below |
-| `GCP_PROJECT_ID` | deploy, destroy | Your GCP project ID, e.g. `travelhub-cbayona-prod` |
-| `PULUMI_CONFIG_PASSPHRASE` | deploy, destroy, seed | Empty string `""` — this project uses no passphrase encryption |
-| `CODECOV_TOKEN` | ci (optional) | Token from [codecov.io](https://codecov.io) for coverage reports — omit if you don't use Codecov |
+| `GCP_SA_KEY` | `deploy`, `destroy`, `seed` | Full JSON key of the deploy service account used by GitHub Actions (or configure Workload Identity Federation as an alternative). |
+| `GCP_PROJECT_ID` | `deploy`, `destroy` | GCP project id (e.g. `travelhub-prod`). Pulumi and gcloud commands read this. |
+| `PULUMI_CONFIG_PASSPHRASE` | `deploy`, `destroy`, `seed` | Set to empty string `""` for this repo (Pulumi secrets not encrypted with a passphrase). |
+| `CODECOV_TOKEN` | `ci` (optional) | Optional — upload coverage reports to Codecov. |
+| `SMTP_USER` | `deploy` | Pulumi writes this to Secret Manager (plain value). |
+| `SMTP_PASS` | `deploy` | Pulumi writes this to Secret Manager (secret). |
+| `SMTP_FROM` | `deploy` | Sender address used by notification emails (plain). |
+| `STRIPE_SECRET_KEY` | `deploy` | Stripe secret key (secret Pulumi config). |
+| `STRIPE_WEBHOOK_SECRET` | `deploy` | Stripe webhook secret (secret Pulumi config). |
+| `STRIPE_PUBLISHABLE_KEY` | `deploy`, `mobile workflows`, `publish-release` | Build-time value used when compiling frontend/mobile; present in several workflows. |
+| `AUTH_JWT_SECRET` | `deploy` | JWT secret used by services (secret Pulumi config). |
+| `FIREBASE_PROJECT_ID` | `deploy` | Firebase project id (plain). |
+| `FIREBASE_CLIENT_EMAIL` | `deploy` | Firebase service account client email (secret Pulumi config). |
+| `FIREBASE_PRIVATE_KEY` | `deploy` | Firebase private key (secret — store with newline characters escaped). |
 
-That is everything. No AWS credentials, no other secrets.
+Notes:
+- Pulumi will create per-service DB secrets named like `travelhub-db-url-<service>`; you do not need to create those manually.
+- Mobile and some CI workflows reference `STRIPE_PUBLISHABLE_KEY` and will fail the build if it is not present.
+- If you prefer not to store a long JSON service-account key in GitHub, consider configuring Workload Identity Federation (GCP) and giving the Actions runner an identity with the required roles.
+
+### Quick Pulumi config examples
+
+After the first `pulumi up` (or before building the frontend) you may want to set Pulumi config values that are consumed by the `deploy.yml` workflow. From the repo root run:
+
+```bash
+# inside pulumi/ directory: set plain values
+cd pulumi
+pulumi config set --stack prod smtpUser "smtp@example.com"
+pulumi config set --stack prod smtpFrom "noreply@example.com"
+
+# set secret values
+pulumi config set --stack prod --secret smtpPass "super-secret-smtp-pass"
+pulumi config set --stack prod --secret stripeSecretKey "sk_live_xxx"
+pulumi config set --stack prod stripePublishableKey "pk_live_xxx"
+pulumi config set --stack prod --secret authJwtSecret "replace-with-random-secret"
+
+# set firebase (private key may contain newlines; easier to use GitHub secret and let the workflow set Pulumi)
+pulumi config set --stack prod firebaseProjectId "my-firebase-project"
+cd ..
+```
+
+Tip: For values that contain newlines (for example `FIREBASE_PRIVATE_KEY`) prefer setting them using the GitHub web UI or `gh secret` so newlines are preserved correctly. Example with the GitHub CLI:
+
+```bash
+printf '%s' "$FIREBASE_PRIVATE_KEY" | gh secret set FIREBASE_PRIVATE_KEY
+```
+
+### Helpful `gcloud` / `gsutil` snippets
+
+If you need to create the Pulumi state bucket and grant the deployer SA access manually:
+
+```bash
+# create bucket
+gcloud storage buckets create gs://travelhub-pulumi-state --location=us-central1 --uniform-bucket-level-access
+
+# grant SA access to the bucket (replace ${SA_EMAIL})
+gsutil iam ch serviceAccount:${SA_EMAIL}:roles/storage.objectAdmin gs://travelhub-pulumi-state
+```
+
+### Deploy env examples (local)
+
+You can run Pulumi locally for debugging. Example with explicit stack and region:
+
+```bash
+PULUMI_STACK=prod REGION=us-central1 PULUMI_CONFIG_PASSPHRASE="" pulumi up --cwd pulumi
+
+# read outputs
+PULUMI_STACK=prod pulumi stack output --cwd pulumi
+```
+
+### Exact `pulumi config set` commands used by the workflows
+
+These are the precise `pulumi config set` invocations the `deploy.yml` workflow runs (replace `prod` with your stack name if different). Run them from the repository root using `--cwd pulumi` or change directory into `pulumi/` first.
+
+```bash
+# plain values
+pulumi config set --stack prod --cwd pulumi smtpHost "smtp.gmail.com"
+pulumi config set --stack prod --cwd pulumi smtpUser "smtp@example.com"
+pulumi config set --stack prod --cwd pulumi smtpFrom "noreply@example.com"
+pulumi config set --stack prod --cwd pulumi stripePublishableKey "pk_live_xxx"
+pulumi config set --stack prod --cwd pulumi firebaseProjectId "my-firebase-project"
+
+# secret values (use --secret to encrypt into Pulumi state)
+pulumi config set --stack prod --cwd pulumi --secret smtpPass "super-secret-smtp-pass"
+pulumi config set --stack prod --cwd pulumi --secret stripeSecretKey "sk_live_xxx"
+pulumi config set --stack prod --cwd pulumi --secret stripeWebhookSecret "whsec_xxx"
+pulumi config set --stack prod --cwd pulumi --secret authJwtSecret "replace-with-random-secret"
+pulumi config set --stack prod --cwd pulumi --secret firebaseClientEmail "firebase-client@example.iam.gserviceaccount.com"
+pulumi config set --stack prod --cwd pulumi --secret firebasePrivateKey "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+```
+
+Note: The workflow sets these values from GitHub Secrets automatically before calling `pulumi up`. If you run the workflow, you do not need to run these manually unless you are debugging locally.
+
+### Note on Service Account roles
+
+The deploy service account needs a broad set of roles to provision infra. The `gcloud` snippet earlier in this doc lists the roles used by the project; keep that list as the minimal set for deployment. If you prefer tighter RBAC, grant the roles incrementally and test the workflow to see which permission fails.
 
 ---
 
@@ -212,6 +302,44 @@ One secret per service that has a database, named `travelhub-db-url-{service}`:
 | `travelhub-db-url-integration-service` | integration-service |
 
 The `DATABASE_URL` secret contains the full PostgreSQL connection string including the password. Cloud Run injects it at startup via `secretKeyRef` — the plaintext password never appears in Cloud Run environment variable configuration.
+
+### Vendor webhook secrets (Hotelbeds / TravelClick / RoomRaccoon)
+
+Third-party webhook signing secrets used by `integration-service` are not created automatically by Pulumi in this repo. You must provision them in Secret Manager and make them available to the Cloud Run service. Recommended steps:
+
+1. Create the secret in Secret Manager:
+
+```bash
+# replace NAME and VALUE
+gcloud secrets create travelhub-webhook-hotelbeds --replication-policy="automatic"
+printf '%s' "${HOTELBEDS_SECRET}" | gcloud secrets versions add travelhub-webhook-hotelbeds --data-file=-
+```
+
+2. Attach the secret to the Cloud Run service (so it becomes an env var at runtime):
+
+```bash
+# set SECRET_ENV_NAME on the Cloud Run service to point to Secret Manager secret latest version
+gcloud run services update travelhub-integration-service \
+  --region=us-central1 \
+  --update-secrets WEBHOOK_SECRET_HOTELBEDS=travelhub-webhook-hotelbeds:latest
+```
+
+Repeat for `travelhub-webhook-travelclick` and `travelhub-webhook-roomraccoon` (env var names expected by the service: `WEBHOOK_SECRET_TRAVELCLICK`, `WEBHOOK_SECRET_ROOMRACCOON`).
+
+Note: If you prefer to manage these via Pulumi, add Pulumi `appConfig` keys and secret manager creation to `pulumi/index.ts`, then run `pulumi up` so the change is tracked in IaC.
+
+### FX conversion flag (`FX_MOCK`)
+
+`integration-service` is deployed with `FX_MOCK=true` by default (see `pulumi/index.ts` where `plainEnv["FX_MOCK"] = "true"`). This means price conversions are mocked in production unless changed.
+
+To change this permanently, update `pulumi/index.ts` to source the flag from `pulumi.Config()` or remove the hard-coded value, then run:
+
+```bash
+cd pulumi
+pulumi up --stack prod
+```
+
+Avoid updating Cloud Run env vars manually when Pulumi controls the service; manual edits will be overwritten by the next `pulumi up`.
 
 ### Services (Cloud Run)
 9 Cloud Run services, one per microservice. All use a shared service account (`travelhub-cloudrun@PROJECT.iam.gserviceaccount.com`).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Nx 22 monorepo for the TravelHub platform — a hotel and travel booking system 
 └── mobile/                   # Expo 54 + React Native app (port 8081)
 ```
 
+## Documentation
+
+La documentación técnica principal está centralizada en `docs/`. Empieza por el índice:
+
+- [docs/index.md](docs/index.md) — índice y Quickstart (despliegue rápido)
+
+Dentro de `docs/` encontrarás guías más detalladas como `setup.md`, `architecture.md`, `deployment.md` y `ci-and-testing.md`.
+
 ## Prerequisites
 
 - Node.js 24
@@ -102,48 +110,33 @@ GitHub Actions runs on every push to `main` and on pull requests:
 
 ## Deployment
 
-Infrastructure is managed with [Pulumi](https://www.pulumi.com/) in `pulumi/`. State lives in S3 (`s3://travelhub-pulumi-state`). Services run on AWS App Runner; the frontend is served from S3 + CloudFront.
+Infrastructure is managed with [Pulumi](https://www.pulumi.com/) in `pulumi/`. The current deployment target is Google Cloud Platform: Cloud Run, Cloud SQL, Memorystore, Pub/Sub, Cloud Storage and Secret Manager.
 
-### Prerequisites
+For full production deployment instructions and required secrets, consulte `DEPLOYMENT.md`.
 
-- [Pulumi CLI](https://www.pulumi.com/docs/install/)
-- AWS credentials with access to the account
-- `cd pulumi && npm install`
-
-### Deploy locally
+### Local deployment commands
 
 ```bash
-cd pulumi
-
-# Export credentials (needed when using AWS SSO / login sessions)
-eval "$(aws configure export-credentials --format env)"
-
-# Preview
-AWS_REGION=us-east-1 PULUMI_CONFIG_PASSPHRASE="" pulumi preview --stack prod
-
-# Deploy backend (builds Docker images, pushes to ECR, updates App Runner)
-AWS_REGION=us-east-1 PULUMI_CONFIG_PASSPHRASE="" pulumi up --stack prod
-
-# Deploy frontend (run after pulumi up)
-cd ..
-pnpm run build:frontend
-BUCKET=$(AWS_REGION=us-east-1 PULUMI_CONFIG_PASSPHRASE="" pulumi stack output frontendBucket --stack prod --cwd pulumi)
-CDN_ID=$(AWS_REGION=us-east-1 PULUMI_CONFIG_PASSPHRASE="" pulumi stack output cdnId --stack prod --cwd pulumi)
-aws s3 sync dist/frontend/ "s3://${BUCKET}/" --delete
-aws cloudfront create-invalidation --distribution-id "${CDN_ID}" --paths "/*"
+pnpm run infra:install
+pnpm run infra:preview
+pnpm run infra:up
+pnpm run infra:down
+pnpm run deploy:frontend
 ```
 
-### Deploy via GitHub Actions
+### GitHub Actions deployment
 
-Trigger manually: **Actions → Deploy → Run workflow**
+El workflow de despliegue está en `.github/workflows/deploy.yml`.
 
-Required secrets in the `production` GitHub Environment:
+- `deploy-infra` se ejecuta cuando cambian archivos en `pulumi/` o el despliegue se dispara manualmente.
+- `deploy-services` construye y despliega únicamente los servicios afectados.
+- `deploy-frontend` despliega el frontend cuando solo cambia `frontend/`.
 
-| Secret | Description |
-|---|---|
-| `AWS_ACCESS_KEY_ID` | IAM key with ECR / App Runner / S3 / CloudFront access |
-| `AWS_SECRET_ACCESS_KEY` | Corresponding secret key |
-| `PULUMI_CONFIG_PASSPHRASE` | Empty string (no secret encryption on this project) |
+### Notas clave
+
+- El estado de Pulumi se almacena en un bucket de GCS.
+- El frontend se despliega con `scripts/deploy-frontend.mjs`.
+- El proveedor actual es GCP, no AWS.
 
 ## Code Quality
 
@@ -161,7 +154,7 @@ Required secrets in the `production` GitHub Environment:
 | Language | TypeScript 5 |
 | Testing | Jest 30, ts-jest |
 | Linting | ESLint 9 (flat config), Prettier |
-| Deployment | AWS App Runner (services), S3 + CloudFront (frontend) |
+| Deployment | GCP Cloud Run, Cloud SQL, Cloud Storage + Pulumi |
 
 ## Learn More
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,78 @@
+# Arquitectura del proyecto
+
+TravelHub es un monorepo Nx que agrupa:
+
+- 9 microservicios NestJS bajo `services/`
+- Una aplicación web React en `frontend/`
+- Una aplicación móvil Expo + React Native en `mobile/`
+
+## Visión general
+
+```
+/ (raíz del monorepo)
+├── services/          # microservicios NestJS
+├── frontend/          # SPA React + Vite
+├── mobile/            # Expo / React Native
+├── docs/              # documentación técnica
+├── pulumi/            # infraestructura en GCP
+├── scripts/           # scripts de despliegue / utilidades
+└── package.json       # scripts globales y dependencias del monorepo
+```
+
+## Servicios y responsabilidades
+
+| Servicio | Puerto local | Función principal |
+|---|---|---|
+| `api-gateway` | 3000 | Punto de entrada, JWT, rate limiting, reenvío de requests |
+| `auth-service` | 3001 | Registro, login, JWT, MFA, RBAC |
+| `search-service` | 3002 | Búsqueda de propiedades, ranking, caché|
+| `inventory-service` | 3003 | Gestión de habitaciones, tarifas y disponibilidad |
+| `booking-service` | 3004 | Reservas, carrito, cálculos de tarifa |
+| `payment-service` | 3005 | Integración con Stripe/MercadoPago/PayPal |
+| `notification-service` | 3006 | Emails y notificaciones push |
+| `partners-service` | 3007 | Portal de socio/hotel, métricas y pagos |
+| `integration-service` | 3008 | Webhooks PMS, importes CSV, mapeo externo |
+
+## Flujo de solicitudes
+
+- El frontend y la app móvil llaman a `api-gateway`.
+- `api-gateway` valida JWT y reenvía cabeceras confiables (`x-user-id`, `x-user-email`, `x-user-role`, etc.) a los microservicios.
+- Los microservicios no validan JWT directamente; confían en el gateway.
+
+## Comunicación entre servicios
+
+- Principalmente HTTP/REST entre servicios.
+- También se usan eventos para sincronizar datos y notificaciones.
+- Localmente el broker puede ser RabbitMQ; en producción se usa Pub/Sub de GCP.
+
+## Frontend y mobile
+
+- `frontend/` es una SPA React 19 con Vite 7.
+- `mobile/` es una app Expo 54 con React Native 0.81.
+- Ambos consumen APIs expuestas por `api-gateway`.
+
+## Herramientas y tecnología
+
+- Monorepo: Nx 22.5
+- Backend: NestJS 11, Node.js 24
+- Frontend: React 19 + Vite 7
+- Mobile: Expo 54 + React Native 0.81
+- Base de datos: PostgreSQL (Cloud SQL en producción)
+- Cache/cola: Redis / Pub/Sub
+- Infraestructura: Pulumi en `pulumi/`
+- Tests: Jest + Nx
+- Lint: ESLint plano + Prettier
+
+## Cómo está organizado el código
+
+- Cada servicio tiene su propia carpeta bajo `services/<nombre>/`.
+- El entrypoint en cada servicio es `src/main.ts`.
+- El frontend arranca desde `frontend/src/main.tsx`.
+- La app móvil usa rutas de Expo en `mobile/app/`.
+
+## Por qué esta arquitectura
+
+- Separación de responsabilidades por servicio.
+- Escalado independiente de frontend, mobile y backend.
+- Despliegue con Pulumi facilita la infraestructura como código.
+- Uso de Nx para orquestar builds, tests y lint en todo el monorepo.

--- a/docs/ci-and-testing.md
+++ b/docs/ci-and-testing.md
@@ -1,0 +1,65 @@
+# CI y pruebas
+
+Este documento explica el flujo de integración continua y los comandos de prueba disponibles.
+
+## CI actual
+
+La integración continua se define en `.github/workflows/ci.yml` y tiene estos pasos:
+
+1. `typecheck` — Ejecuta `pnpm run typecheck`.
+2. `lint` — Ejecuta `nx affected -t lint` para los proyectos cambiados.
+3. `build` — Ejecuta `nx affected -t build` para los proyectos cambiados.
+4. `test` — Ejecuta `nx run-many -t test --outputStyle=static -- --coverage`.
+
+El flujo usa `NX_DAEMON=false` y `NX_TUI=false` para estabilidad.
+
+## Comandos principales
+
+```bash
+pnpm run typecheck
+pnpm run lint
+pnpm run test
+pnpm run build
+```
+
+## Comandos Nx afectados
+
+```bash
+pnpm run affected:build
+pnpm run affected:test
+pnpm run affected:lint
+```
+
+## Probar proyectos individuales
+
+```bash
+pnpm exec nx test auth-service
+pnpm exec nx test booking-service
+pnpm exec nx test frontend
+pnpm exec nx test mobile
+pnpm exec nx lint frontend
+pnpm exec nx lint mobile
+```
+
+## Pruebas end-to-end mobile
+
+```bash
+pnpm run e2e:mobile
+pnpm run e2e:mobile:register
+pnpm run e2e:mobile:record
+```
+
+## Lint y formato
+
+- `pnpm run lint` — todos los proyectos
+- `pnpm run lint:fix` — corrige automáticamente problemas donde sea posible
+
+## Cobertura
+
+El job `test` sube cobertura a Codecov si está disponible usando `CODECOV_TOKEN`.
+
+## Notas útiles
+
+- Si un cambio solo afecta un subconjunto de proyectos, `nx affected` evita ejecutar tests/build innecesarios.
+- Use `nx graph` para visualizar dependencias entre proyectos.
+- `pnpm test` ejecuta todos los tests del monorepo en un solo comando.

--- a/docs/ci-and-testing.md
+++ b/docs/ci-and-testing.md
@@ -1,17 +1,54 @@
 # CI y pruebas
 
-Este documento explica el flujo de integración continua y los comandos de prueba disponibles.
+Este documento explica el flujo de integración continua, los comandos de prueba disponibles y los workflows principales del repo.
 
 ## CI actual
 
-La integración continua se define en `.github/workflows/ci.yml` y tiene estos pasos:
+La integración continua se define en `.github/workflows/ci.yml` y cubre:
 
 1. `typecheck` — Ejecuta `pnpm run typecheck`.
-2. `lint` — Ejecuta `nx affected -t lint` para los proyectos cambiados.
-3. `build` — Ejecuta `nx affected -t build` para los proyectos cambiados.
-4. `test` — Ejecuta `nx run-many -t test --outputStyle=static -- --coverage`.
+2. `lint` — Ejecuta `pnpm exec nx affected -t lint --base=$NX_BASE --head=$NX_HEAD --outputStyle=static`.
+3. `build` — Ejecuta `pnpm exec nx affected -t build --base=$NX_BASE --head=$NX_HEAD --outputStyle=static`.
+4. `test` — Ejecuta `pnpm exec nx run-many -t test --outputStyle=static -- --coverage`.
 
-El flujo usa `NX_DAEMON=false` y `NX_TUI=false` para estabilidad.
+El workflow se dispara en `push` a `main` y en `pull_request`, y define `NX_DAEMON=false`, `NX_TUI=false` y `HUSKY=0` para estabilidad en Actions.
+
+## Workflows del repositorio
+
+### `.github/workflows/ci.yml`
+
+- Validación principal de PRs y pushes a `main`.
+- Comprueba compilación, lint, tests y subida de cobertura a Codecov.
+- Usa `nx affected` para evitar ejecutar tareas innecesarias en cambios pequeños.
+
+### `.github/workflows/deploy.yml`
+
+- Se ejecuta después de CI completado en `main` o de forma manual con `workflow_dispatch`.
+- Detecta cambios en `pulumi/`, en `frontend/` y en servicios afectados para decidir si hacer:
+  - un deploy completo de infraestructura y servicios (`deploy-infra`), o
+  - un despliegue rápido solo de servicios afectados (`deploy-services`).
+- El deploy completo también actualiza el frontend con `scripts/deploy-frontend.mjs`.
+- Requiere secretos GCP y Pulumi en GitHub Secrets, como `GCP_SA_KEY`, `PULUMI_CONFIG_PASSPHRASE`, `SMTP_PASS`, `STRIPE_SECRET_KEY`, `AUTH_JWT_SECRET`, `FIREBASE_PRIVATE_KEY`, etc.
+
+### `.github/workflows/e2e-frontend.yml`
+
+- Workflow manual para ejecutar pruebas Playwright contra el frontend desplegado.
+- Valida que `GATEWAY_URL` y `FRONTEND_URL` estén presentes como repository variables o entradas del workflow.
+- Instala navegadores Playwright, espera que el API y el frontend estén saludables y corre `pnpm exec nx e2e frontend`.
+- Genera reportes HTML en `playwright-report/frontend` y ofrece artefactos por test en `test-results/frontend`.
+
+### `.github/workflows/e2e-mobile.yml`
+
+- Workflow manual para ejecutar pruebas móviles con Maestro sobre Android.
+- Construye un APK local con `eas build` y ejecuta los flujos en `e2e/mobile/flows/`.
+- Requiere un usuario de bypass (`e2e@travelhub.com / E2eTest1234!`) ya existente en el entorno desplegado.
+
+### Otros workflows útiles
+
+- `.github/workflows/mobile-build.yml` — build de app móvil para iOS/Android.
+- `.github/workflows/seed.yml` — ejecución manual de seeds o datos de ejemplo.
+- `.github/workflows/destroy.yml` — destrucción manual de infraestructura de Pulumi.
+- `.github/workflows/publish-release.yml` — public release flow que valida, prueba y publica la app.
 
 ## Comandos principales
 
@@ -41,25 +78,77 @@ pnpm exec nx lint frontend
 pnpm exec nx lint mobile
 ```
 
+## Pruebas end-to-end frontend
+
+La carpeta de E2E web está en `e2e/frontend/` y usa Playwright.
+
+Comandos disponibles:
+
+```bash
+pnpm run e2e:web
+pnpm run e2e:web:headed
+pnpm run e2e:web:ui
+pnpm run e2e:web:flow <ruta-o-archivo>
+pnpm run e2e:web:report
+pnpm run e2e:web:record
+```
+
+El workflow de GitHub Actions ejecuta el target `pnpm exec nx e2e frontend` desde `.github/workflows/e2e-frontend.yml`.
+
 ## Pruebas end-to-end mobile
 
 ```bash
 pnpm run e2e:mobile
-pnpm run e2e:mobile:register
-pnpm run e2e:mobile:record
+pnpm run e2e:mobile:flow <flow-name>
+pnpm run e2e:mobile:report
+pnpm run e2e:mobile:record <flow-name>
+```
+
+## Pruebas de carga
+
+La carga y los smoke tests están documentados en `performance-testing.md`.
+
+- `performance-tests/` — tests locales y scripts de k6
+- `.github/workflows/performance-testing.yml` — workflow manual de GitHub Actions
+
+En GitHub Actions puedes ejecutar el workflow manual con los perfiles:
+
+- `smoke` — smoke tests de búsqueda y booking
+- `load` — test de carga de búsqueda
+- `all` — ejecuta smoke + load
+
+Localmente puedes correr los escenarios con npm desde `performance-tests`:
+
+```bash
+cd performance-tests
+npm run test:load:search
+```
+
+O ejecutar todos los tests de carga y smoke:
+
+```bash
+cd performance-tests
+npm run test:all
+```
+
+Estas pruebas esperan que la variable `GATEWAY_URL` apunte al API Gateway activo:
+
+```bash
+GATEWAY_URL=http://localhost:3000 npm run test:load:search
 ```
 
 ## Lint y formato
 
-- `pnpm run lint` — todos los proyectos
-- `pnpm run lint:fix` — corrige automáticamente problemas donde sea posible
+- `pnpm run lint` — todos los proyectos.
+- `pnpm run lint:fix` — corrige automáticamente problemas donde sea posible.
 
 ## Cobertura
 
-El job `test` sube cobertura a Codecov si está disponible usando `CODECOV_TOKEN`.
+El job `test` sube cobertura a Codecov usando `CODECOV_TOKEN` si está disponible.
 
 ## Notas útiles
 
 - Si un cambio solo afecta un subconjunto de proyectos, `nx affected` evita ejecutar tests/build innecesarios.
-- Use `nx graph` para visualizar dependencias entre proyectos.
 - `pnpm test` ejecuta todos los tests del monorepo en un solo comando.
+- Para pruebas web E2E locales, asegúrate de tener el frontend desplegado o disponible en `FRONTEND_URL` antes de correr Playwright.
+- El `e2e-frontend` workflow espera que el API Gateway y el frontend estén accesibles y saludables antes de lanzar las pruebas.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,89 @@
+# Despliegue
+
+Este proyecto usa Pulumi para la infraestructura y GitHub Actions para el despliegue.
+
+> El documento completo de despliegue está en `DEPLOYMENT.md`.
+
+## Resumen de la infraestructura
+
+- Cloud Run para los 9 microservicios
+- Cloud SQL para PostgreSQL
+- Memorystore para Redis
+- Pub/Sub para eventos en producción
+- Cloud Storage para el frontend
+- Secret Manager para secretos
+- Pulumi state en un bucket GCS
+
+## Flujo de despliegue
+
+### GitHub Actions
+
+El workflow `deploy.yml` se ejecuta cuando:
+
+- se completa el workflow `CI` en la rama `main`
+- se ejecuta manualmente con `workflow_dispatch`
+
+El workflow tiene tres caminos:
+
+1. `deploy-infra` — Si cambian archivos en `pulumi/` o se fuerza manualmente.
+2. `deploy-services` — Si cambian servicios NestJS pero no la infraestructura.
+3. `deploy-frontend` — Si cambia solo el frontend.
+
+### Qué hace `deploy-infra`
+
+- Instala dependencias de `pulumi/`
+- Autentica con Google Cloud usando `GCP_SA_KEY`
+- Configura Docker para Artifact Registry
+- Ejecuta `pulumi up` con la pila apuntando a GCP
+- Despliega el frontend con `pnpm run deploy:frontend`
+
+### Qué hace `deploy-services`
+
+- Construye y sube imágenes Docker de los servicios afectados
+- Usa `gcloud run deploy` para actualizar los servicios Cloud Run correspondientes
+
+### Qué hace `deploy-frontend`
+
+- Compila el frontend
+- Sincroniza los archivos de `dist/frontend/` con el bucket de Cloud Storage
+
+## Comandos locales de infraestructura
+
+```bash
+pnpm run infra:install
+pnpm run infra:preview
+pnpm run infra:up
+pnpm run infra:down
+pnpm run deploy:frontend
+```
+
+## Script de frontend
+
+El frontend se despliega con `scripts/deploy-frontend.mjs`, que:
+
+- obtiene `frontendBucket`, `gatewayUrl` y `stripePublishableKey` desde Pulumi
+- compila el frontend con las variables correctas
+- sincroniza los archivos a Cloud Storage
+
+## Secretos importantes
+
+La configuración de despliegue requiere secretos de GitHub Actions, como:
+
+- `GCP_SA_KEY`
+- `GCP_PROJECT_ID`
+- `PULUMI_CONFIG_PASSPHRASE`
+- `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM`
+- `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PUBLISHABLE_KEY`
+- `AUTH_JWT_SECRET`
+- `FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`
+
+## Nota de plataforma
+
+La infraestructura actual está definida para Google Cloud Platform, no para AWS.
+
+## Enlaces útiles
+
+- `DEPLOYMENT.md`
+- `pulumi/Pulumi.yaml`
+- `.github/workflows/deploy.yml`
+- `scripts/deploy-frontend.mjs`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+# TravelHub — Documentation Index
+
+Esta carpeta contiene la documentación técnica y de operaciones para comprender, ejecutar y desplegar TravelHub.
+
+Contenido (orden recomendado):
+
+1. Quickstart
+   - [Quickstart: Deploy rápido](quickstart-deploy.md)
+2. Setup
+   - [Setup local](setup.md)
+3. Deployment
+   - [Deployment (Pulumi + GCP)](deployment.md)
+   - [Pulumi reference](pulumi/README.md)
+4. Architecture
+   - [Arquitectura y servicios](architecture.md)
+5. CI & Testing
+   - [CI y testing](ci-and-testing.md)
+6. Services
+   - [integration-service](integration-service.md)
+   - Otros servicios: `services/<name>` (por crear)
+7. Runbooks & Ops
+   - `runbooks/` (checklists, rollback, verificación)
+8. Security & Secrets
+   - `secrets.md` (mapa de secretos y prácticas)
+9. Troubleshooting
+   - `troubleshooting.md`
+
+Cómo usar este índice:
+- Empieza por el `Quickstart` si necesitas desplegar rápido en `prod`.
+- Abre `Setup` para preparar una máquina de desarrollo.
+- Consulta `Deployment` y `Pulumi reference` para cambios en infraestructura.
+
+Si falta una página aquí, abre una issue o crea un PR con la nueva doc bajo `docs/`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ Contenido (orden recomendado):
    - [Arquitectura y servicios](architecture.md)
 5. CI & Testing
    - [CI y testing](ci-and-testing.md)
+   - [Performance testing](performance-testing.md)
 6. Services
    - [integration-service](integration-service.md)
    - Otros servicios: `services/<name>` (por crear)

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -1,0 +1,62 @@
+# Performance testing
+
+Esta guía describe cómo ejecutar pruebas de carga y smoke para TravelHub.
+
+## Qué cubre
+
+El repositorio tiene un workflow manual de GitHub Actions en `.github/workflows/performance-testing.yml` que usa `k6` para:
+
+- smoke test de búsqueda (`smoke/search`)
+- smoke test de booking (`smoke/booking`)
+- test de carga de búsqueda (`load/search`)
+
+## Workflow de GitHub Actions
+
+`performance-testing.yml` tiene estos inputs:
+
+- `profile` — `smoke`, `load`, `all`
+- `gateway_url` — URL del API Gateway desplegado (opcional). Si no se pasa, usa la variable de repositorio `GATEWAY_URL`.
+
+Perfiles disponibles:
+
+- `smoke` — ejecuta `scenarios/smoke/search.js` y `scenarios/smoke/booking.js`
+- `load` — ejecuta `scenarios/load/search.js`
+- `all` — ejecuta smoke + load
+
+Los resultados se suben como artefactos del workflow desde `performance-tests/results/`.
+
+## Comandos locales
+
+Desde el directorio `performance-tests/` puedes ejecutar directamente los tests de k6:
+
+```bash
+cd performance-tests
+npm install
+npm run test:load:search
+```
+
+Para ejecutar todas las pruebas smoke y carga:
+
+```bash
+npm run test:all
+```
+
+Para ejecutar solo las pruebas smoke:
+
+```bash
+npm run test:smoke:all
+```
+
+## Variables de entorno
+
+Los scripts de `performance-tests/` esperan que `GATEWAY_URL` apunte al API Gateway activo:
+
+```bash
+GATEWAY_URL=http://localhost:3000 npm run test:load:search
+```
+
+## Notas
+
+- `test:load:search` genera `results/results-search-load.json` y un reporte HTML en `results/summary-search-load.html`.
+- Las pruebas de carga son especialmente útiles para validar la capacidad del API Gateway y del servicio de búsqueda bajo trafico sostenido.
+- Asegúrate de tener un entorno estable antes de ejecutar `load` para evitar resultados no representativos.

--- a/docs/quickstart-deploy.md
+++ b/docs/quickstart-deploy.md
@@ -1,0 +1,78 @@
+# Quickstart — Deploy rápido (prod)
+
+Resumen de 1 página para que un ingeniero nuevo despliegue TravelHub en la pila `prod`.
+
+Prerequisitos locales:
+
+- Tener `gcloud`, `pulumi`, `pnpm` y `node` instalados y autenticados.
+- Acceso al proyecto GCP y permiso para crear recursos (o usar CI que tiene permisos).
+- Archivo de cuenta de servicio GCP (JSON) si vas a ejecutar Pulumi localmente.
+
+Pasos mínimos (local)
+
+1. Clona y entra al repo:
+
+```bash
+git clone <repo-url>
+cd Proyecto-final-grupo1
+pnpm install
+```
+
+2. Entra a la carpeta `pulumi` y crea la pila `prod` (ejemplo):
+
+```bash
+cd pulumi
+pulumi stack init prod
+```
+
+3. Configura los valores requeridos (ejemplos):
+
+```bash
+# GCP
+pulumi config set --stack prod gcp:project <GCP_PROJECT_ID>
+pulumi config set --stack prod gcp:region <GCP_REGION>
+
+# Secrets y claves (usar --secret para valores sensibles)
+pulumi config set --secret --stack prod authJwtSecret <AUTH_JWT_SECRET>
+pulumi config set --secret --stack prod stripeSecretKey <STRIPE_SECRET>
+pulumi config set --secret --stack prod stripeWebhookSecret <STRIPE_WEBHOOK_SECRET>
+pulumi config set --stack prod stripePublishableKey <STRIPE_PUBLISHABLE_KEY>
+pulumi config set --stack prod smtpHost <SMTP_HOST>
+pulumi config set --stack prod smtpUser <SMTP_USER>
+pulumi config set --secret --stack prod smtpPass <SMTP_PASS>
+pulumi config set --stack prod firebaseProjectId <FIREBASE_PROJECT_ID>
+pulumi config set --secret --stack prod firebaseClientEmail <FIREBASE_CLIENT_EMAIL>
+pulumi config set --secret --stack prod firebasePrivateKey '<FIREBASE_PRIVATE_KEY_JSON>'
+
+# Opcional: pasar la key del service account como secret
+pulumi config set --secret --stack prod gcpServiceAccountKey "$(cat service-account.json)"
+```
+
+Nota: en CI usamos GitHub Secrets y el workflow escribe estos `pulumi config set` desde los secrets — no es necesario repetirlo manualmente en CI.
+
+4. Desplegar (probar en local con Pulumi):
+
+```bash
+pnpm --filter @travelhub/pulumi exec pulumi up --stack prod --yes
+```
+
+5. Comprobar servicios:
+
+```bash
+# Ver servicios Cloud Run
+gcloud run services list --platform managed --region <GCP_REGION>
+
+# Probar health endpoint (ejemplo, sustituir HOST por el URL de Cloud Run)
+curl -fsS https://<SERVICE_HOST>/health
+```
+
+Despliegue mediante CI
+
+- La pipeline `deploy.yml` del repo realiza build de imágenes, sube a Artifact Registry y ejecuta `pulumi up` usando los GitHub Secrets. Asegura que las Secrets listadas en `docs/deployment.md` estén añadidas en el repositorio.
+
+Si algo falla
+
+- Revisa `pulumi` logs y el output del workflow en GitHub Actions.
+- Usa `pulumi stack output` para ver URLs y recursos creados.
+
+¿Necesitas que añada un script `scripts/pulumi-config.sh` para automatizar la creación de estos config a partir de variables de entorno? (puedo generarlo si quieres).

--- a/docs/quickstart-deploy.md
+++ b/docs/quickstart-deploy.md
@@ -25,6 +25,21 @@ cd pulumi
 pulumi stack init prod
 ```
 
+> Si vas a desplegar desde cero en otro proyecto GCP, asegúrate de usar `gcloud auth login` y el proyecto correcto:
+>
+> ```bash
+gcloud auth login
+> gcloud config set project <GCP_PROJECT_ID>
+> ```
+>
+> Luego crea la pila con un nombre adecuado para ese proyecto, por ejemplo:
+>
+> ```bash
+> pulumi stack init prod
+> # o
+> pulumi stack init <nuevo-stack>
+> ```
+>
 3. Configura los valores requeridos (ejemplos):
 
 ```bash
@@ -75,4 +90,30 @@ Si algo falla
 - Revisa `pulumi` logs y el output del workflow en GitHub Actions.
 - Usa `pulumi stack output` para ver URLs y recursos creados.
 
-¿Necesitas que añada un script `scripts/pulumi-config.sh` para automatizar la creación de estos config a partir de variables de entorno? (puedo generarlo si quieres).
+### Script de configuración rápida
+
+También puedes automatizar la creación de los valores de configuración con el helper. Si usas otro stack, pásalo como primer argumento:
+
+```bash
+bash ./scripts/pulumi-config.sh prod
+# o para otro stack
+bash ./scripts/pulumi-config.sh <stack-name>
+```
+
+El script usa estas variables de entorno:
+
+- `GCP_PROJECT_ID`
+- `GCP_REGION`
+- `AUTH_JWT_SECRET`
+- `STRIPE_SECRET_KEY`
+- `STRIPE_WEBHOOK_SECRET`
+- `STRIPE_PUBLISHABLE_KEY`
+- `SMTP_HOST`
+- `SMTP_USER`
+- `SMTP_PASS`
+- `FIREBASE_PROJECT_ID`
+- `FIREBASE_CLIENT_EMAIL`
+- `FIREBASE_PRIVATE_KEY`
+- `GCP_SERVICE_ACCOUNT_KEY` o `GCP_SERVICE_ACCOUNT_KEY_FILE`
+
+Si no quieres usar un archivo JSON, exporta `GCP_SERVICE_ACCOUNT_KEY` con el contenido del key file.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,121 @@
+# Setup local del proyecto
+
+Este documento describe cómo preparar el entorno y levantar el proyecto localmente.
+
+## Requisitos mínimos
+
+- Node.js 24.x
+- pnpm 10.x
+- Git
+- Para mobile: Expo CLI y un emulador iOS/Android o Expo Go en un dispositivo físico.
+- Opcional: Docker y Docker Compose para levantar dependencias locales.
+
+## Clonar el repositorio
+
+```bash
+git clone <repo-url>
+cd Proyecto-final-grupo1
+```
+
+## Instalar dependencias
+
+```bash
+pnpm install
+```
+
+## Levantar la aplicación completa localmente
+
+```bash
+pnpm start
+```
+
+Esto ejecuta `nx run-many -t serve` y levanta todos los servicios y el frontend en modo de desarrollo.
+
+## Levantar servicios individuales
+
+```bash
+pnpm run serve:api-gateway
+pnpm run serve:auth
+pnpm run serve:search
+pnpm run serve:inventory
+pnpm run serve:booking
+pnpm run serve:payment
+pnpm run serve:notification
+pnpm run serve:partners
+pnpm run serve:integration
+pnpm run serve:frontend
+```
+
+## Mobile
+
+```bash
+pnpm run start:mobile
+```
+
+En macOS puedes lanzar directamente:
+
+```bash
+pnpm run run:ios
+```
+
+En Android:
+
+```bash
+pnpm run run:android
+```
+
+## Build local
+
+Compilar todos los proyectos:
+
+```bash
+pnpm run build
+```
+
+Compilar solo los servicios:
+
+```bash
+pnpm run build:services
+```
+
+Compilar solo el frontend:
+
+```bash
+pnpm run build:frontend
+```
+
+## Pruebas y lint
+
+```bash
+pnpm test
+pnpm run lint
+pnpm run lint:fix
+```
+
+Comandos de Nx afectados:
+
+```bash
+pnpm run affected:build
+pnpm run affected:test
+pnpm run affected:lint
+```
+
+## Docker (opcional)
+
+Si deseas levantar el proyecto con Docker para desarrollo:
+
+```bash
+pnpm run docker:dev
+```
+
+Para detener los contenedores locales:
+
+```bash
+pnpm run docker:down
+```
+
+## Notas para mobile
+
+- Use `npx expo install <paquete>` cuando agregue nuevas dependencias de Expo/React Native.
+- Si el emulador no arranca, valide que el SDK de Android o Xcode estén configurados correctamente.
+- El servidor Expo se ofrece en `http://localhost:8081`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -31,6 +31,24 @@ pnpm start
 
 Esto ejecuta `nx run-many -t serve` y levanta todos los servicios y el frontend en modo de desarrollo.
 
+## Despliegue local a GCP
+
+Si necesitas desplegar desde tu máquina a un proyecto GCP nuevo, usa la guía de Quickstart y el helper de configuración:
+
+- [docs/quickstart-deploy.md](quickstart-deploy.md)
+- `scripts/pulumi-config.sh`
+
+El flujo típico es:
+
+```bash
+cd pulumi
+pulumi stack init prod
+bash ../scripts/pulumi-config.sh prod
+pulumi up --stack prod --yes
+```
+
+Asegúrate de haber iniciado sesión con `gcloud auth login` y de haber configurado el proyecto correcto con `gcloud config set project <GCP_PROJECT_ID>`.
+
 ## Levantar servicios individuales
 
 ```bash

--- a/scripts/pulumi-config.sh
+++ b/scripts/pulumi-config.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+STACK=${1:-prod}
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR/pulumi"
+
+require() {
+  local name=$1
+  local value=${2:-}
+  if [[ -z "$value" ]]; then
+    echo "ERROR: Missing required environment variable $name" >&2
+    exit 1
+  fi
+}
+
+require "GCP_PROJECT_ID" "$GCP_PROJECT_ID"
+require "GCP_REGION" "$GCP_REGION"
+require "AUTH_JWT_SECRET" "$AUTH_JWT_SECRET"
+require "STRIPE_SECRET_KEY" "$STRIPE_SECRET_KEY"
+require "STRIPE_WEBHOOK_SECRET" "$STRIPE_WEBHOOK_SECRET"
+require "STRIPE_PUBLISHABLE_KEY" "$STRIPE_PUBLISHABLE_KEY"
+require "SMTP_HOST" "$SMTP_HOST"
+require "SMTP_USER" "$SMTP_USER"
+require "SMTP_PASS" "$SMTP_PASS"
+require "FIREBASE_PROJECT_ID" "$FIREBASE_PROJECT_ID"
+require "FIREBASE_CLIENT_EMAIL" "$FIREBASE_CLIENT_EMAIL"
+require "FIREBASE_PRIVATE_KEY" "$FIREBASE_PRIVATE_KEY"
+
+if [[ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]]; then
+  GCP_SERVICE_ACCOUNT_KEY_CONTENT="$GCP_SERVICE_ACCOUNT_KEY"
+elif [[ -n "${GCP_SERVICE_ACCOUNT_KEY_FILE:-}" ]]; then
+  if [[ ! -f "$GCP_SERVICE_ACCOUNT_KEY_FILE" ]]; then
+    echo "ERROR: GCP_SERVICE_ACCOUNT_KEY_FILE file does not exist: $GCP_SERVICE_ACCOUNT_KEY_FILE" >&2
+    exit 1
+  fi
+  GCP_SERVICE_ACCOUNT_KEY_CONTENT="$(cat "$GCP_SERVICE_ACCOUNT_KEY_FILE")"
+else
+  GCP_SERVICE_ACCOUNT_KEY_CONTENT=""
+fi
+
+pulumi config set --stack "$STACK" gcp:project "$GCP_PROJECT_ID"
+pulumi config set --stack "$STACK" gcp:region "$GCP_REGION"
+
+pulumi config set --secret --stack "$STACK" authJwtSecret "$AUTH_JWT_SECRET"
+pulumi config set --secret --stack "$STACK" stripeSecretKey "$STRIPE_SECRET_KEY"
+pulumi config set --secret --stack "$STACK" stripeWebhookSecret "$STRIPE_WEBHOOK_SECRET"
+pulumi config set --stack "$STACK" stripePublishableKey "$STRIPE_PUBLISHABLE_KEY"
+pulumi config set --stack "$STACK" smtpHost "$SMTP_HOST"
+pulumi config set --stack "$STACK" smtpUser "$SMTP_USER"
+pulumi config set --secret --stack "$STACK" smtpPass "$SMTP_PASS"
+pulumi config set --stack "$STACK" firebaseProjectId "$FIREBASE_PROJECT_ID"
+pulumi config set --secret --stack "$STACK" firebaseClientEmail "$FIREBASE_CLIENT_EMAIL"
+pulumi config set --secret --stack "$STACK" firebasePrivateKey "$FIREBASE_PRIVATE_KEY"
+
+if [[ -n "$GCP_SERVICE_ACCOUNT_KEY_CONTENT" ]]; then
+  pulumi config set --secret --stack "$STACK" gcpServiceAccountKey "$GCP_SERVICE_ACCOUNT_KEY_CONTENT"
+else
+  echo "NOTE: GCP_SERVICE_ACCOUNT_KEY / GCP_SERVICE_ACCOUNT_KEY_FILE is not set; using default gcloud credentials if available."
+fi
+
+echo "Pulumi config values set for stack '$STACK'."


### PR DESCRIPTION
Switches deployment and infra documentation from AWS to GCP (Cloud Run, Cloud SQL, GCS, Secret Manager) and restructures all guides accordingly. Adds detailed Spanish-language docs covering architecture, CI/testing, deployment, setup, and quickstart to centralize onboarding and operational knowledge. Improves clarity for required secrets, deployment workflows, and local development, making onboarding and production ops easier for new engineers.

