### PR TITLE
fix(perf-test): autenticar el smoke de booking contra el api-gateway

### DIFF
--- a/.github/workflows/e2e-frontend.yml
+++ b/.github/workflows/e2e-frontend.yml
@@ -98,7 +98,7 @@ jobs:
         env:
           API_BASE_URL: ${{ github.event.inputs.api_url || vars.GATEWAY_URL }}
           FRONTEND_BASE_URL: ${{ github.event.inputs.frontend_url || vars.FRONTEND_URL }}
-        run: pnpm exec nx e2e frontend
+        run: pnpm exec nx e2e frontend-e2e
 
       - name: Upload Playwright HTML report
         if: always()

--- a/performance-tests/lib/auth.js
+++ b/performance-tests/lib/auth.js
@@ -1,0 +1,34 @@
+import http from "k6/http";
+
+// Logs in via the api-gateway and returns the access token.
+// The e2e seed user (e2e@travelhub.com) has mfaRequired=false, so the first
+// POST /api/auth/login returns a LoginTokenResponse directly. Other users
+// would require a second POST /api/auth/login/mfa step.
+export function login(gatewayUrl, email, password) {
+  const res = http.post(
+    `${gatewayUrl}/api/auth/login`,
+    JSON.stringify({ email, password }),
+    {
+      headers: { "Content-Type": "application/json", "X-Load-Test": "true" },
+      timeout: "45s",
+    },
+  );
+
+  if (res.status !== 200) {
+    throw new Error(
+      `Login failed for ${email}: ${res.status} ${res.body?.slice(0, 200)}`,
+    );
+  }
+
+  const body = JSON.parse(res.body);
+  if (body.mfaRequired) {
+    throw new Error(
+      `Login for ${email} returned an MFA challenge; the smoke test expects an mfaRequired=false account.`,
+    );
+  }
+  if (!body.accessToken) {
+    throw new Error(`Login for ${email} returned no accessToken`);
+  }
+
+  return body.accessToken;
+}

--- a/performance-tests/lib/http.js
+++ b/performance-tests/lib/http.js
@@ -5,37 +5,43 @@ const BASE_HEADERS = {
   "X-Load-Test": "true",
 };
 
-// GET with automatic X-Load-Test header and optional extra tags.
-export function get(url, tags = {}) {
+function buildHeaders(auth) {
+  return auth
+    ? { ...BASE_HEADERS, Authorization: `Bearer ${auth}` }
+    : BASE_HEADERS;
+}
+
+// GET with automatic X-Load-Test header, optional Bearer auth, and optional extra tags.
+export function get(url, tags = {}, auth = null) {
   return http.get(url, {
-    headers: BASE_HEADERS,
+    headers: buildHeaders(auth),
     tags,
     timeout: "45s",
   });
 }
 
-// POST with JSON body, X-Load-Test header, and optional extra tags.
-export function post(url, body, tags = {}) {
+// POST with JSON body, X-Load-Test header, optional Bearer auth, and optional extra tags.
+export function post(url, body, tags = {}, auth = null) {
   return http.post(url, JSON.stringify(body), {
-    headers: BASE_HEADERS,
+    headers: buildHeaders(auth),
     tags,
     timeout: "45s",
   });
 }
 
-// PATCH with optional JSON body, X-Load-Test header, and optional extra tags.
-export function patch(url, body, tags = {}) {
+// PATCH with optional JSON body, X-Load-Test header, optional Bearer auth, and optional extra tags.
+export function patch(url, body, tags = {}, auth = null) {
   return http.patch(url, body != null ? JSON.stringify(body) : null, {
-    headers: BASE_HEADERS,
+    headers: buildHeaders(auth),
     tags,
     timeout: "45s",
   });
 }
 
-// DELETE with X-Load-Test header and optional extra tags.
-export function del(url, tags = {}) {
+// DELETE with X-Load-Test header, optional Bearer auth, and optional extra tags.
+export function del(url, tags = {}, auth = null) {
   return http.del(url, null, {
-    headers: BASE_HEADERS,
+    headers: buildHeaders(auth),
     tags,
     timeout: "45s",
   });

--- a/performance-tests/scenarios/smoke/booking.js
+++ b/performance-tests/scenarios/smoke/booking.js
@@ -20,6 +20,7 @@ import { check } from "k6";
 import { textSummary } from "https://jslib.k6.io/k6-summary/0.0.2/index.js";
 import { htmlReport } from "https://raw.githubusercontent.com/benc-uk/k6-reporter/main/dist/bundle.js";
 import { post, patch, get } from "../../lib/http.js";
+import { login } from "../../lib/auth.js";
 import { jitter } from "../../lib/utils.js";
 import {
   BOOKING_BOOKER_ID,
@@ -27,6 +28,11 @@ import {
   BOOKING_PROPERTY_ID,
   BOOKING_PARTNER_ID,
 } from "../../fixtures/seed-data.js";
+
+// Seeded MFA-bypass account (services/auth-service/scripts/seed.ts).
+// All PATCH /reservations/* endpoints require a valid JWT at the gateway.
+const E2E_EMAIL    = __ENV.E2E_EMAIL    || "e2e@travelhub.com";
+const E2E_PASSWORD = __ENV.E2E_PASSWORD || "E2eTest1234!";
 
 // ─── Config ───────────────────────────────────────────────────────────────────
 
@@ -76,7 +82,7 @@ function datePair() {
   };
 }
 
-function createReservation(checkIn, checkOut) {
+function createReservation(checkIn, checkOut, token) {
   return post(
     `${BOOKING}/reservations`,
     {
@@ -88,47 +94,51 @@ function createReservation(checkIn, checkOut) {
       checkOut,
     },
     { name: "create_reservation" },
+    token,
   );
 }
 
-function submitReservation(id) {
-  return patch(`${BOOKING}/reservations/${id}/submit`, null, { name: "submit_reservation" });
+function submitReservation(id, token) {
+  return patch(`${BOOKING}/reservations/${id}/submit`, null, { name: "submit_reservation" }, token);
 }
 
-function confirmReservation(id) {
-  return patch(`${BOOKING}/reservations/${id}/confirm`, null, { name: "confirm_reservation" });
+function confirmReservation(id, token) {
+  return patch(`${BOOKING}/reservations/${id}/confirm`, null, { name: "confirm_reservation" }, token);
 }
 
-function getReservation(id) {
-  return get(`${BOOKING}/reservations/${id}`, { name: "get_reservation" });
+function getReservation(id, token) {
+  return get(`${BOOKING}/reservations/${id}`, { name: "get_reservation" }, token);
 }
 
-function updateGuestInfo(id) {
+function updateGuestInfo(id, token) {
   return patch(
     `${BOOKING}/reservations/${id}/guest-info`,
     { firstName: "Smoke", lastName: "Test", email: "smoke@travelhub.com", phone: "+52 555 000 0000" },
     { name: "update_guest_info" },
+    token,
   );
 }
 
-function failReservation(id) {
+function failReservation(id, token) {
   return patch(
     `${BOOKING}/reservations/${id}/fail`,
     { reason: "Your card was declined." },
     { name: "fail_reservation" },
+    token,
   );
 }
 
-function cancelReservation(id) {
+function cancelReservation(id, token) {
   return patch(
     `${BOOKING}/reservations/${id}/cancel`,
     { reason: "Smoke test cancellation" },
     { name: "cancel_reservation" },
+    token,
   );
 }
 
-function reholdReservation(id) {
-  return patch(`${BOOKING}/reservations/${id}/rehold`, null, { name: "rehold_reservation" });
+function reholdReservation(id, token) {
+  return patch(`${BOOKING}/reservations/${id}/rehold`, null, { name: "rehold_reservation" }, token);
 }
 
 // ─── Scenarios ────────────────────────────────────────────────────────────────
@@ -138,10 +148,10 @@ function reholdReservation(id) {
  * Full flow: create (held) → guest-info → submit (submitted) → confirm (confirmed).
  * Verifies HTTP statuses and response shape at each step.
  */
-function happyPath() {
+function happyPath(token) {
   const { checkIn, checkOut } = datePair();
 
-  const resRes = createReservation(checkIn, checkOut);
+  const resRes = createReservation(checkIn, checkOut, token);
   const resOk = check(resRes, {
     "happy_path: reservation 201":       (r) => r.status === 201,
     "happy_path: status held":            (r) => { try { return JSON.parse(r.body).status === "held"; } catch { return false; } },
@@ -151,18 +161,18 @@ function happyPath() {
   if (!resOk || resRes.status !== 201) return;
   const { id } = JSON.parse(resRes.body);
 
-  const patchRes = updateGuestInfo(id);
+  const patchRes = updateGuestInfo(id, token);
   check(patchRes, {
     "happy_path: guest-info 200": (r) => r.status === 200,
   });
 
-  const submitRes = submitReservation(id);
+  const submitRes = submitReservation(id, token);
   check(submitRes, {
     "happy_path: submit 200":       (r) => r.status === 200,
     "happy_path: status submitted":  (r) => { try { return JSON.parse(r.body).status === "submitted"; } catch { return false; } },
   });
 
-  const confirmRes = confirmReservation(id);
+  const confirmRes = confirmReservation(id, token);
   check(confirmRes, {
     "happy_path: confirm 200":      (r) => r.status === 200,
     "happy_path: status confirmed": (r) => { try { return JSON.parse(r.body).status === "confirmed"; } catch { return false; } },
@@ -174,15 +184,15 @@ function happyPath() {
  * Two POST /reservations with the same booker/room/dates return the same reservation ID.
  * The partial unique index on held prevents duplicate active holds.
  */
-function idempotency() {
+function idempotency(token) {
   const { checkIn, checkOut } = datePair();
 
-  const r1 = createReservation(checkIn, checkOut);
+  const r1 = createReservation(checkIn, checkOut, token);
   check(r1, { "idempotency: 1st reservation 201": (r) => r.status === 201 });
   if (r1.status !== 201) return;
   const id1 = JSON.parse(r1.body).id;
 
-  const r2 = createReservation(checkIn, checkOut); // identical params
+  const r2 = createReservation(checkIn, checkOut, token); // identical params
   const id2 = (r2.status === 200 || r2.status === 201) ? JSON.parse(r2.body).id : null;
   check(r2, {
     "idempotency: 2nd call is 2xx":       (r) => r.status >= 200 && r.status < 300,
@@ -190,8 +200,8 @@ function idempotency() {
   });
 
   // Cleanup — confirm so the held is released
-  submitReservation(id1);
-  confirmReservation(id1);
+  submitReservation(id1, token);
+  confirmReservation(id1, token);
 }
 
 /**
@@ -199,14 +209,14 @@ function idempotency() {
  * Creates a reservation and fetches it by ID.
  * Verifies the response shape and status.
  */
-function getReservationScenario() {
+function getReservationScenario(token) {
   const { checkIn, checkOut } = datePair();
 
-  const resRes = createReservation(checkIn, checkOut);
+  const resRes = createReservation(checkIn, checkOut, token);
   if (resRes.status !== 201) return;
   const { id } = JSON.parse(resRes.body);
 
-  const getRes = getReservation(id);
+  const getRes = getReservation(id, token);
   check(getRes, {
     "get_reservation: 200":              (r) => r.status === 200,
     "get_reservation: id matches":       (r) => { try { return JSON.parse(r.body).id === id; } catch { return false; } },
@@ -214,48 +224,48 @@ function getReservationScenario() {
   });
 
   // Cleanup
-  submitReservation(id);
-  confirmReservation(id);
+  submitReservation(id, token);
+  confirmReservation(id, token);
 }
 
 /**
  * 3 — Submit without prior held (idempotency guard)
  * Submitting an already-submitted or confirmed reservation returns 404.
  */
-function submitAlreadyPending() {
+function submitAlreadyPending(token) {
   const { checkIn, checkOut } = datePair();
 
-  const resRes = createReservation(checkIn, checkOut);
+  const resRes = createReservation(checkIn, checkOut, token);
   if (resRes.status !== 201) return;
   const { id } = JSON.parse(resRes.body);
 
   // First submit: ok
-  const s1 = submitReservation(id);
+  const s1 = submitReservation(id, token);
   check(s1, { "double_submit: 1st submit 200": (r) => r.status === 200 });
 
   // Second submit on already-submitted: rejected (404 — not held anymore)
-  const s2 = submitReservation(id);
+  const s2 = submitReservation(id, token);
   check(s2, { "double_submit: 2nd submit rejected": (r) => r.status === 404 || r.status === 409 || r.status === 400 });
 
   // Cleanup
-  confirmReservation(id);
+  confirmReservation(id, token);
 }
 
 /**
  * 4 — Full lifecycle check
  * Creates, submits, confirms and verifies final state via GET.
  */
-function fullLifecycle() {
+function fullLifecycle(token) {
   const { checkIn, checkOut } = datePair();
 
-  const resRes = createReservation(checkIn, checkOut);
+  const resRes = createReservation(checkIn, checkOut, token);
   if (resRes.status !== 201) return;
   const { id } = JSON.parse(resRes.body);
 
-  submitReservation(id);
-  confirmReservation(id);
+  submitReservation(id, token);
+  confirmReservation(id, token);
 
-  const getRes = getReservation(id);
+  const getRes = getReservation(id, token);
   check(getRes, {
     "lifecycle: final status confirmed": (r) => { try { return JSON.parse(r.body).status === "confirmed"; } catch { return false; } },
   });
@@ -267,15 +277,15 @@ function fullLifecycle() {
  * Verifies the reservation reaches the cancelled state and the inventory hold
  * is released (subsequent create on the same dates should succeed).
  */
-function cancelHeld() {
+function cancelHeld(token) {
   const { checkIn, checkOut } = datePair();
 
-  const resRes = createReservation(checkIn, checkOut);
+  const resRes = createReservation(checkIn, checkOut, token);
   check(resRes, { "cancel_held: reservation 201": (r) => r.status === 201 });
   if (resRes.status !== 201) return;
   const { id } = JSON.parse(resRes.body);
 
-  const cancelRes = cancelReservation(id);
+  const cancelRes = cancelReservation(id, token);
   check(cancelRes, {
     "cancel_held: cancel 200":         (r) => r.status === 200,
     "cancel_held: status cancelled":   (r) => { try { return JSON.parse(r.body).status === "cancelled"; } catch { return false; } },
@@ -283,11 +293,11 @@ function cancelHeld() {
   });
 
   // Inventory should be freed — same dates can be held again
-  const retryRes = createReservation(checkIn, checkOut);
+  const retryRes = createReservation(checkIn, checkOut, token);
   check(retryRes, { "cancel_held: room available after cancel": (r) => r.status === 201 });
   if (retryRes.status === 201) {
-    submitReservation(JSON.parse(retryRes.body).id);
-    confirmReservation(JSON.parse(retryRes.body).id);
+    submitReservation(JSON.parse(retryRes.body).id, token);
+    confirmReservation(JSON.parse(retryRes.body).id, token);
   }
 }
 
@@ -296,18 +306,18 @@ function cancelHeld() {
  * Creates a reservation, submits it (submitted), then cancels.
  * Verifies the reservation reaches the cancelled state.
  */
-function cancelSubmitted() {
+function cancelSubmitted(token) {
   const { checkIn, checkOut } = datePair();
 
-  const resRes = createReservation(checkIn, checkOut);
+  const resRes = createReservation(checkIn, checkOut, token);
   check(resRes, { "cancel_submitted: reservation 201": (r) => r.status === 201 });
   if (resRes.status !== 201) return;
   const { id } = JSON.parse(resRes.body);
 
-  const submitRes = submitReservation(id);
+  const submitRes = submitReservation(id, token);
   check(submitRes, { "cancel_submitted: submit 200": (r) => r.status === 200 });
 
-  const cancelRes = cancelReservation(id);
+  const cancelRes = cancelReservation(id, token);
   check(cancelRes, {
     "cancel_submitted: cancel 200":       (r) => r.status === 200,
     "cancel_submitted: status cancelled": (r) => { try { return JSON.parse(r.body).status === "cancelled"; } catch { return false; } },
@@ -319,21 +329,21 @@ function cancelSubmitted() {
  * Full retry path: held → submitted → failed → held (rehold) → submitted → confirmed.
  * Verifies the reservation recovers from a failed payment and reaches confirmed.
  */
-function failAndRetry() {
+function failAndRetry(token) {
   const { checkIn, checkOut } = datePair();
 
-  const resRes = createReservation(checkIn, checkOut);
+  const resRes = createReservation(checkIn, checkOut, token);
   check(resRes, { "fail_retry: reservation 201": (r) => r.status === 201 });
   if (resRes.status !== 201) return;
   const { id } = JSON.parse(resRes.body);
 
   // Transition to submitted
-  const submitRes = submitReservation(id);
+  const submitRes = submitReservation(id, token);
   check(submitRes, { "fail_retry: submit 200": (r) => r.status === 200 });
   if (submitRes.status !== 200) return;
 
   // Simulate Stripe payment_failed webhook response
-  const failRes = failReservation(id);
+  const failRes = failReservation(id, token);
   check(failRes, {
     "fail_retry: fail 200":        (r) => r.status === 200,
     "fail_retry: status failed":   (r) => { try { return JSON.parse(r.body).status === "failed"; } catch { return false; } },
@@ -342,7 +352,7 @@ function failAndRetry() {
   if (failRes.status !== 200) return;
 
   // Re-acquire inventory hold (failed → held)
-  const reholdRes = reholdReservation(id);
+  const reholdRes = reholdReservation(id, token);
   check(reholdRes, {
     "fail_retry: rehold 200":      (r) => r.status === 200,
     "fail_retry: status held":     (r) => { try { return JSON.parse(r.body).status === "held"; } catch { return false; } },
@@ -351,10 +361,10 @@ function failAndRetry() {
   if (reholdRes.status !== 200) return;
 
   // Retry: submit → confirm
-  const submitRes2 = submitReservation(id);
+  const submitRes2 = submitReservation(id, token);
   check(submitRes2, { "fail_retry: 2nd submit 200": (r) => r.status === 200 });
 
-  const confirmRes = confirmReservation(id);
+  const confirmRes = confirmReservation(id, token);
   check(confirmRes, {
     "fail_retry: confirm 200":      (r) => r.status === 200,
     "fail_retry: status confirmed": (r) => { try { return JSON.parse(r.body).status === "confirmed"; } catch { return false; } },
@@ -374,8 +384,15 @@ const SCENARIOS = [
   failAndRetry,
 ];
 
-export default function () {
-  SCENARIOS[__ITER % SCENARIOS.length]();
+export function setup() {
+  // Single login at the start of the test; reused across all iterations.
+  // Token TTL is 3600s (auth.types.ts) — well beyond a 5-minute smoke run.
+  const token = login(GATEWAY_URL, E2E_EMAIL, E2E_PASSWORD);
+  return { token };
+}
+
+export default function (data) {
+  SCENARIOS[__ITER % SCENARIOS.length](data.token);
   jitter(300, 700); // 0.3–1s think time between iterations
 }
 

--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -481,7 +481,7 @@ function makeCloudRun(
         connector: vpcConnector.id,
         egress: "PRIVATE_RANGES_ONLY",
       },
-      scaling: { minInstanceCount: 0, maxInstanceCount: 1 },
+      scaling: { minInstanceCount: 1, maxInstanceCount: 1 },
       containers: [{
         image: img.imageName,
         ports: [{ containerPort: 8080 }],


### PR DESCRIPTION
## Descripción

Tres cambios relacionados con los smoke tests / despliegue de los entornos remotos:

1. **`performance-tests/scenarios/smoke/booking.js`** fallaba ~50% de los checks porque el api-gateway rechaza con 401 los `PATCH /api/booking/reservations/:id/{submit,confirm,cancel,fail,rehold}` (esas rutas no están en `services/api-gateway/src/auth/public-routes.ts`). El smoke nunca enviaba `Authorization`. Ahora `setup()` hace login con la cuenta semilla `e2e@travelhub.com` (mfaRequired=false) y propaga el JWT a cada escenario.

2. **`.github/workflows/e2e-frontend.yml`** invocaba `nx e2e frontend`, target inexistente. El proyecto Nx se llama `frontend-e2e` (`e2e/frontend/project.json`), así que ahora corre `nx e2e frontend-e2e`.

3. **`pulumi/index.ts`** sube `minInstanceCount` de 0 a 1 en los 9 Cloud Run. Hace permanente el cambio que ya se aplicó manualmente vía gcloud para eliminar cold starts. Sin esto, el próximo `pulumi up` revertía la configuración. **Impacto en costos:** 9 instancias siempre activas 24/7 en us-central1.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [x] Infraestructura / configuración

## Cómo probar

Smoke de booking contra staging (requiere que `e2e@travelhub.com` esté seedeada):
\`\`\`bash
cd performance-tests
GATEWAY_URL=https://<staging-gateway>.run.app npm run test:smoke:booking
\`\`\`
Espera 100% de checks pasados (antes pasaba el 48.27%).

Workflow E2E Frontend: lanzar manualmente *Actions → E2E Frontend (Playwright) → Run workflow* y verificar que el paso *Run Playwright* ya no falla con \`Cannot find configuration for task frontend:e2e\`.

Pulumi: \`cd pulumi && pulumi preview\` debería mostrar un cambio de \`minInstanceCount: 0 → 1\` en los 9 servicios y nada más.

## Issues relacionados

N/A

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [ ] Se ejecutaron las pruebas existentes sin regresiones (\`pnpm test\`)
- [ ] El linter no reporta errores (\`pnpm run lint\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)