### PR TITLE
fix(e2e-frontend): resolver page.goto al bucket del frontend, no al host-root

### DIFF
--- a/e2e/frontend/src/pages/login.page.ts
+++ b/e2e/frontend/src/pages/login.page.ts
@@ -4,7 +4,7 @@ export class LoginPage {
   constructor(private readonly page: Page) {}
 
   async goto(): Promise<void> {
-    await this.page.goto('/#/login');
+    await this.page.goto('#/login');
   }
 
   async fillAndSubmit(email: string, password: string): Promise<void> {

--- a/e2e/frontend/src/pages/register.page.ts
+++ b/e2e/frontend/src/pages/register.page.ts
@@ -4,7 +4,7 @@ export class RegisterPage {
   constructor(private readonly page: Page) {}
 
   async goto(): Promise<void> {
-    await this.page.goto('/#/register');
+    await this.page.goto('#/register');
   }
 
   async fillAndSubmit(params: {

--- a/e2e/frontend/src/pages/search.page.ts
+++ b/e2e/frontend/src/pages/search.page.ts
@@ -14,7 +14,7 @@ export class SearchPage {
       checkOut: BOOKING_WINDOW.checkOut,
       guests: String(BOOKING_WINDOW.guests),
     });
-    await this.page.goto(`/#/search?${search.toString()}`);
+    await this.page.goto(`#/search?${search.toString()}`);
   }
 
   // Each result card exposes a "Reservar" button. The seed has 3 Cancún

--- a/e2e/frontend/src/pages/trips.page.ts
+++ b/e2e/frontend/src/pages/trips.page.ts
@@ -4,7 +4,7 @@ export class TripsPage {
   constructor(private readonly page: Page) {}
 
   async goto(): Promise<void> {
-    await this.page.goto('/#/trips');
+    await this.page.goto('#/trips');
     // The trips heading is a styled <p>, not an actual heading element. Wait
     // on the URL and the "Mis reservaciones" text anywhere on the page (the
     // navbar entry doesn't count — it's a button — but the page title does).


### PR DESCRIPTION
## Descripción

Los tests de Playwright contra el entorno desplegado fallaban con timeout esperando los labels del login. El screenshot del artifact mostraba la respuesta XML de GCS:

\`\`\`
<Error>
  <Code>MissingSecurityHeader</Code>
  <Message>Your request was missing a required header.</Message>
  <Details>Authorization</Details>
</Error>
\`\`\`

Causa: las page objects llaman \`page.goto('/#/login')\` (con barra inicial). Cuando \`FRONTEND_BASE_URL\` está apuntando a \`https://storage.googleapis.com/travelhub-frontend-travelhub-cbayona-prod/index.html\`, \`new URL('/#/login', baseURL)\` se resuelve a \`https://storage.googleapis.com/#/login\` — el path queda **sin el nombre del bucket**, y GCS responde con el error de arriba (no es que el bucket no sea público; es que la URL no apunta a ningún bucket).

Quitando la barra inicial, \`new URL('#/login', baseURL)\` sólo cambia el hash y conserva el path completo:

- Local (\`http://localhost:4200\`) → \`http://localhost:4200/#/login\` ✓ (igual que antes)
- Prod (\`.../index.html\`) → \`.../index.html#/login\` ✓ (antes apuntaba a host-root)

Afecta a 4 page objects: \`login.page.ts\`, \`register.page.ts\`, \`search.page.ts\`, \`trips.page.ts\`.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [ ] Infraestructura / configuración

## Cómo probar

Local:
\`\`\`bash
pnpm exec nx e2e frontend-e2e
\`\`\`

Contra el entorno desplegado: lanzar manualmente *Actions → E2E Frontend (Playwright) → Run workflow* con la variable \`FRONTEND_URL\` apuntando al bucket (\`.../index.html\`). El paso \`Run Playwright\` debería completar sin timeouts en los formularios de login/registro.

## Issues relacionados

N/A

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [ ] Se ejecutaron las pruebas existentes sin regresiones (\`pnpm test\`)
- [ ] El linter no reporta errores (\`pnpm run lint\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)