### PR TITLE
fix(ci): quitar pasos Materialize Firebase config en publish-release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -123,12 +123,6 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Materialize Firebase config
-        uses: ./.github/actions/firebase-config
-        with:
-          plist-b64: ${{ secrets.GOOGLE_SERVICES_PLIST_B64 }}
-          json-b64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
-
       - name: Build Android (local)
         working-directory: mobile
         env:
@@ -184,12 +178,6 @@ jobs:
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
-
-      - name: Materialize Firebase config
-        uses: ./.github/actions/firebase-config
-        with:
-          plist-b64: ${{ secrets.GOOGLE_SERVICES_PLIST_B64 }}
-          json-b64: ${{ secrets.GOOGLE_SERVICES_JSON_B64 }}
 
       - name: Build iOS (local)
         working-directory: mobile


### PR DESCRIPTION
## Descripción

Limpieza pendiente de #257. Ese PR eliminó el composite action \`.github/actions/firebase-config/\` y sus invocaciones en \`e2e-mobile.yml\` y \`mobile-build.yml\`, pero **olvidó** quitar las mismas referencias en \`publish-release.yml\` (jobs *Build / Android* y *Build / iOS*). Como el action ya no existe, ambas jobs fallan al iniciar:

\`\`\`
Can't find 'action.yml' ... under '.github/actions/firebase-config'.
\`\`\`

Como los archivos \`GoogleService-Info.plist\` y \`google-services.json\` están commiteados desde el PR #256, basta con borrar los pasos: EAS los encuentra en disco después de \`actions/checkout\`.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [ ] Infraestructura / configuración

## Cómo probar

Lanzar manualmente *Actions → Publish Release → Run workflow* con cualquier versión de prueba; las jobs *Build / Android* y *Build / iOS* deberían pasar el inicio sin el error de action faltante.

## Issues relacionados

N/A

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [ ] Se ejecutaron las pruebas existentes sin regresiones (\`pnpm test\`)
- [ ] El linter no reporta errores (\`pnpm run lint\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)