### PR TITLE
fix(perf-test): aceptar 2xx en el login, no sólo 200

### DIFF
--- a/performance-tests/lib/auth.js
+++ b/performance-tests/lib/auth.js
@@ -14,7 +14,9 @@ export function login(gatewayUrl, email, password) {
     },
   );
 
-  if (res.status !== 200) {
+  // NestJS @Post returns 201 by default and auth-service does not override it,
+  // so accept any 2xx instead of pinning to 200.
+  if (res.status < 200 || res.status >= 300) {
     throw new Error(
       `Login failed for ${email}: ${res.status} ${res.body?.slice(0, 200)}`,
     );


### PR DESCRIPTION
## Descripción

Cuando se ejecutó *Performance Testing* contra el entorno desplegado, el smoke de booking fallaba en \`setup()\` con:

\`\`\`
Error: Login failed for e2e@travelhub.com: 201 {"mfaRequired":false,"accessToken":"***
\`\`\`

El login efectivamente devuelve el \`accessToken\`, pero \`auth-service\` usa \`@Post("login")\` sin \`@HttpCode(200)\`, así que NestJS responde **201 Created**. El helper \`lib/auth.js\` rechazaba todo lo que no fuera 200 y abortaba el smoke aunque el token llegara correctamente.

Este cambio se quedó fuera del squash-merge del PR #267 (se pusheó al branch después del merge), por eso se abre como PR independiente.

**Fix:** aceptar cualquier 2xx (\`status >= 200 && status < 300\`).

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [ ] Infraestructura / configuración

## Cómo probar

Re-disparar manualmente *Actions → Performance Testing → Run workflow* con el profile \`all\` (o \`smoke/booking\` de forma local) y verificar que el job \`Run smoke/booking\` pase el \`setup()\` sin abortar.

## Issues relacionados

N/A

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [ ] Se ejecutaron las pruebas existentes sin regresiones (\`pnpm test\`)
- [ ] El linter no reporta errores (\`pnpm run lint\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)