### PR TITLE
fix(api-gateway): reenviar stripe-signature y el cuerpo crudo al hacer proxy

### DIFF
--- a/services/api-gateway/src/main.ts
+++ b/services/api-gateway/src/main.ts
@@ -2,7 +2,9 @@ import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  // rawBody: true exposes req.rawBody so the proxy can forward the unmodified
+  // bytes downstream — required for Stripe webhook signature verification.
+  const app = await NestFactory.create(AppModule, { rawBody: true });
   app.enableCors({
     origin: process.env.CORS_ORIGIN?.split(",") ?? ["http://localhost:4200"],
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],

--- a/services/api-gateway/src/proxy.service.ts
+++ b/services/api-gateway/src/proxy.service.ts
@@ -18,8 +18,12 @@ export class ProxyService {
   async forward(targetUrl: string, req: Request): Promise<ProxyResult> {
     const method = req.method.toUpperCase();
     const isBodyless = ["GET", "HEAD", "DELETE"].includes(method);
+    const incomingContentType = req.headers["content-type"];
     const headers: Record<string, string> = {
-      "content-type": "application/json",
+      "content-type":
+        typeof incomingContentType === "string"
+          ? incomingContentType
+          : "application/json",
     };
     if (req.headers.authorization)
       headers["authorization"] = req.headers.authorization;
@@ -29,6 +33,9 @@ export class ProxyService {
       "x-user-role",
       "x-partner-id",
       "x-property-id",
+      // Stripe signs the raw request bytes; the verifier in payment-service
+      // compares this header against req.rawBody, so it must pass through.
+      "stripe-signature",
     ] as const;
     for (const name of passthrough) {
       const value = req.headers[name];
@@ -37,12 +44,19 @@ export class ProxyService {
 
     this.logger.log(`→ ${method} ${targetUrl}`);
 
+    // Prefer rawBody (captured because NestFactory was started with rawBody: true)
+    // so signed payloads like Stripe webhooks aren't re-serialized in transit.
+    const rawBody = (req as Request & { rawBody?: Buffer }).rawBody;
+    const forwardBody = isBodyless
+      ? undefined
+      : (rawBody ?? JSON.stringify(req.body));
+
     let response: globalThis.Response;
     try {
       response = await fetch(targetUrl, {
         method,
         headers,
-        body: isBodyless ? undefined : JSON.stringify(req.body),
+        body: forwardBody,
       });
     } catch (err) {
       this.logger.error(

--- a/services/api-gateway/src/proxy.service.ts
+++ b/services/api-gateway/src/proxy.service.ts
@@ -46,10 +46,15 @@ export class ProxyService {
 
     // Prefer rawBody (captured because NestFactory was started with rawBody: true)
     // so signed payloads like Stripe webhooks aren't re-serialized in transit.
+    // Uint8Array.from(buffer) yields a Uint8Array<ArrayBuffer> that fetch's
+    // BodyInit accepts — Node Buffer is Uint8Array<ArrayBufferLike>, which TS
+    // does not consider assignable to BodyInit since the typed generic was added.
     const rawBody = (req as Request & { rawBody?: Buffer }).rawBody;
-    const forwardBody = isBodyless
+    const forwardBody: BodyInit | undefined = isBodyless
       ? undefined
-      : (rawBody ?? JSON.stringify(req.body));
+      : rawBody
+        ? Uint8Array.from(rawBody)
+        : JSON.stringify(req.body);
 
     let response: globalThis.Response;
     try {


### PR DESCRIPTION
## Descripción

El webhook de Stripe (\`POST /api/payment/payments/webhook\`) fallaba la verificación de firma en \`payment-service\` por dos motivos en el proxy del gateway:

1. **\`stripe-signature\` se descartaba.** El allowlist en \`proxy.service.ts:26-32\` sólo reenviaba 6 headers (\`authorization\` + los 5 identity headers \`x-user-*\`/\`x-partner-*\`/\`x-property-*\`).
2. **El cuerpo se reserializaba** con \`JSON.stringify(req.body)\`. Stripe firma los bytes crudos del request; tras pasar por \`express.json()\` y volver a stringificar, el payload que llega a payment-service ya no coincide con lo firmado.

\`payment-service\` ya está correctamente configurado (\`NestFactory.create(..., { rawBody: true })\` + \`req.rawBody\` en el controller). El bug era exclusivo del gateway.

**Cambios:**
- \`services/api-gateway/src/main.ts\`: \`NestFactory.create(AppModule, { rawBody: true })\` para exponer \`req.rawBody\`.
- \`services/api-gateway/src/proxy.service.ts\`:
  - Añade \`stripe-signature\` a la lista de passthrough.
  - Preserva el \`content-type\` original en vez de hardcodear \`application/json\` (Stripe envía \`application/json; charset=utf-8\`).
  - Reenvía \`req.rawBody\` cuando está disponible y cae a \`JSON.stringify(req.body)\` como fallback (comportamiento original) si no lo está.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [ ] Infraestructura / configuración

## Cómo probar

Local:
\`\`\`bash
pnpm exec nx test api-gateway     # 49/49 pasa
pnpm exec nx lint api-gateway     # 34 warnings preexistentes, 0 nuevos
\`\`\`

En el entorno desplegado (después del deploy):
1. En el Stripe dashboard, dispara un evento de prueba (\`Send test webhook → payment_intent.succeeded\`) apuntando a \`https://travelhub-api-gateway-317344419928.us-central1.run.app/api/payment/payments/webhook\`.
2. Verifica los logs de payment-service en Cloud Run: debe loguear \`Stripe webhook received: payment_intent.succeeded\` en lugar de \`Webhook signature verification failed\`.

## Issues relacionados

N/A

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [x] Se ejecutaron las pruebas existentes sin regresiones (\`pnpm exec nx test api-gateway\`)
- [x] El linter no reporta errores (\`pnpm exec nx lint api-gateway\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)