### PR TITLE
fix(mobile-ios): forzar Swift 6 en pods de Expo para arreglar el build de iOS

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -41,6 +41,7 @@
       ],
       "./plugins/withCoreSplashscreen",
       "./plugins/withAndroidAbiOverride",
+      "./plugins/withExpoPodsSwift6",
       [
         "expo-splash-screen",
         {

--- a/mobile/plugins/withExpoPodsSwift6.js
+++ b/mobile/plugins/withExpoPodsSwift6.js
@@ -1,0 +1,38 @@
+const { withDangerousMod } = require('@expo/config-plugins');
+const fs = require('fs');
+const path = require('path');
+
+const MARKER = '# expo-pods-swift6';
+const SNIPPET = `
+    ${MARKER}
+    installer.pods_project.targets.each do |t|
+      if t.name.start_with?('Expo')
+        t.build_configurations.each do |bc|
+          bc.build_settings['SWIFT_VERSION'] = '6.0'
+        end
+      end
+    end
+`;
+
+module.exports = function withExpoPodsSwift6(config) {
+  return withDangerousMod(config, [
+    'ios',
+    async (cfg) => {
+      const podfilePath = path.join(cfg.modRequest.platformProjectRoot, 'Podfile');
+      let contents = fs.readFileSync(podfilePath, 'utf8');
+      if (contents.includes(MARKER)) return cfg;
+
+      const patched = contents.replace(
+        /(react_native_post_install\([\s\S]*?\)\s*)(\n\s*end)/,
+        `$1\n${SNIPPET}$2`
+      );
+      if (patched === contents) {
+        throw new Error(
+          'withExpoPodsSwift6: could not locate react_native_post_install block in Podfile'
+        );
+      }
+      fs.writeFileSync(podfilePath, patched);
+      return cfg;
+    },
+  ]);
+};


### PR DESCRIPTION
## Descripción

El job **Build / iOS** de `mobile-build.yml` está fallando ([run 26013514121](https://github.com/camila1973/Proyecto-final-grupo1/actions/runs/26013514121/job/76458848199)) al compilar `expo-modules-core@55.0.25` con Xcode 16.4 (`macos-latest`). Síntoma representativo:

```
ExpoReactDelegate.swift:41:39: call to main actor-isolated initializer 'init' in a synchronous nonisolated context
SwiftUIHostingView.swift:45:89: unknown attribute 'MainActor'
SwiftUIHostingView.swift:113/135/142: main actor-isolated instance method '...' cannot be used to satisfy nonisolated requirement from protocol 'AnyExpoSwiftUIHostingView'
PersistentFileLog.swift:79: capture of 'filter' with non-sendable type ... in an isolated closure
```

La causa: el código fuente de expo-modules-core 55 ya usa sintaxis Swift 6 (`@MainActor` en posición de conformance, closures sendable-aware), pero los pods se compilan en modo Swift 5 y rechazan el atributo como desconocido.

**Solución:** un config plugin local que inyecta `SWIFT_VERSION = '6.0'` en el `post_install` del Podfile para todos los targets cuyo nombre empieza por `Expo`. Se hace vía `withDangerousMod` porque `mobile/ios/` se regenera en cada `expo prebuild` (está en `.gitignore`), así que editar el Podfile a mano no persiste en CI.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [x] Infraestructura / configuración

## Cómo probar

1. Lanzar manualmente el workflow apuntando a esta rama:
   ```bash
   gh workflow run mobile-build.yml -f platform=ios --ref fix/ios-build-expo-pods-swift6
   ```
2. Verificar que el step `Build iOS (local)` ya no rompe compilando `expo-modules-core`.
3. (Opcional, en mac local) `cd mobile && npx expo prebuild --clean --platform ios` y confirmar que el `Podfile` generado contiene el marker `# expo-pods-swift6` con el override de `SWIFT_VERSION`.

## Issues relacionados

N/A — fallo de entorno detectado tras el merge de #273; no cierra ni es parte de ningún issue.

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [ ] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [ ] El linter no reporta errores (`pnpm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)