### PR TITLE
fix(pulumi): apuntar Cloud Run al repoDigest, no al tag :latest

### DIFF
--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -483,7 +483,12 @@ function makeCloudRun(
       },
       scaling: { minInstanceCount: 1, maxInstanceCount: 1 },
       containers: [{
-        image: img.imageName,
+        // Pin Cloud Run to the digest-qualified image name. Using img.imageName
+        // resolves to ".../<service>:latest", which is identical across rebuilds —
+        // Pulumi reports no diff on the container, so a fresh image gets pushed
+        // to the registry but Cloud Run keeps serving the old revision. repoDigest
+        // includes the @sha256:… suffix, so every rebuild forces a new revision.
+        image: img.repoDigest,
         ports: [{ containerPort: 8080 }],
         envs: [...plainVars, ...secretVars],
         volumeMounts,


### PR DESCRIPTION
## Descripción

\`gcp.cloudrunv2.Service.template.containers[0].image\` se inicializaba con \`img.imageName\`, que resuelve a \`…/<servicio>:latest\`. Esa cadena no cambia entre rebuilds, así que Pulumi no detecta diff en el container y Cloud Run conserva la revisión vieja apuntando a la imagen vieja — aunque el push acabe de subir bytes nuevos al registry. El resultado es un \"deploy verde\" sin rollout real.

Esto causó que el fix del webhook de Stripe (#274) no llegara a producción después del *Full deploy (Pulumi)*: la imagen del api-gateway se rebuilt con el código nuevo (digest \`sha256:7c07059…\`), pero la única acción que Pulumi tomó sobre Cloud Run fue un update con \`diff: ~scaling\` — sin nueva revisión. Hubo que forzar el rollout manualmente con \`gcloud run services update --image @sha256:7c07059…\`.

\`docker.Image.repoDigest\` incluye el sufijo \`@sha256:…\` y cambia con cada rebuild → Pulumi reporta diff de \`~containers\` → Cloud Run crea una revisión nueva automáticamente.

Aplica a los 9 microservicios porque \`makeCloudRun\` es la fábrica común.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [x] Infraestructura / configuración

## Cómo probar

1. Mergear este PR.
2. Disparar manualmente *Actions → Deploy → Run workflow*.
3. Verificar que las 9 revisiones de Cloud Run muestran un timestamp nuevo después del deploy (\`gcloud run revisions list --service=travelhub-api-gateway --region=us-central1 --limit=2\`).
4. La columna IMAGE de la revisión nueva debe terminar en \`@sha256:…\`, no en \`:latest\`.

Notas:
- En el primer deploy con este cambio, Pulumi reemplazará los 9 \`gcp.cloudrunv2.Service\` (cambio del campo \`image\`). Espera ~5-10 min de rollout.
- El min-instances=1 ya está fijado por código (PR #267), así que no debería haber ventana de \"cold start\" durante la transición.

## Issues relacionados

N/A

## Checklist
- [x] El código compila sin errores (typecheck pulumi/index.ts limpio)
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [ ] Se ejecutaron las pruebas existentes sin regresiones (\`pnpm test\`)
- [ ] El linter no reporta errores (\`pnpm run lint\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)