### PR TITLE
fix(publish-release): seleccionar Xcode estable para el build de iOS

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -158,6 +158,16 @@ jobs:
         with:
           ref: ${{ needs.tag.outputs.sha }}
 
+      # Expo SDK 55 / expo-modules-core 55 ships Swift 6.2 syntax
+      # (@MainActor on protocol conformance — SE-0470). The runner's default
+      # selection is Xcode 16.4 (Swift 6.0), which rejects it as
+      # "unknown attribute 'MainActor'". Pin the latest stable Xcode so the
+      # toolchain matches the source.
+      - name: Select latest stable Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
       - uses: ./.github/actions/setup
 
       - name: Set app version in app.json


### PR DESCRIPTION
## Descripción

El workflow **Publish Release** sigue fallando en el job `Build / iOS` ([run 26017452007](https://github.com/camila1973/Proyecto-final-grupo1/actions/runs/26017452007/job/76470753781)) con los mismos errores de Swift 6.2 / SE-0470 (`unknown attribute 'MainActor'`, `main actor-isolated ... cannot be used to satisfy nonisolated requirement ...`) en `expo-modules-core@55.0.25`.

La causa: `publish-release.yml` define su propio job `build-gh-ios` que no recibió el fix de PR #275 / #276 (que solo tocó `mobile-build.yml`). El runner `macos-latest` selecciona Xcode 16.4 por defecto, cuyo Swift 6.0 no entiende la sintaxis SE-0470 (Xcode 26 / Swift 6.2 sí).

Este PR replica el mismo paso de pin de Xcode en el job de iOS de `publish-release.yml`:

```yaml
- name: Select latest stable Xcode
  uses: maxim-lobanov/setup-xcode@v1
  with:
    xcode-version: latest-stable
```

## Tipo de cambio
- [ ] Nueva funcionalidad
- [x] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [x] Infraestructura / configuración

## Cómo probar

1. Lanzar manualmente el workflow **Publish Release** apuntando a esta rama (input `version` cualquier `vX.Y.Z` de prueba), o esperar al próximo release y verificar que el job `Build / iOS` pasa.
2. En el log del job, confirmar que el step `Select latest stable Xcode` corre antes del build y que `xcode-select -p` (o el `xcode_path` que loguea fastlane) apunta a una Xcode 26.x en lugar de 16.4.

## Issues relacionados

N/A — mismo fallo de entorno tratado en PR #275/#276/#278; este PR cierra el gap en el workflow de release.

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [ ] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [ ] El linter no reporta errores (`pnpm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)