### PR TITLE
chore(pulumi): bajar minInstanceCount de Cloud Run a 0

### DIFF
--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -481,7 +481,7 @@ function makeCloudRun(
         connector: vpcConnector.id,
         egress: "PRIVATE_RANGES_ONLY",
       },
-      scaling: { minInstanceCount: 1, maxInstanceCount: 1 },
+      scaling: { minInstanceCount: 0, maxInstanceCount: 1 },
       containers: [{
         // Pin Cloud Run to the digest-qualified image name. Using img.imageName
         // resolves to ".../<service>:latest", which is identical across rebuilds —


### PR DESCRIPTION
## Descripción
Se reduce el `minInstanceCount` de los servicios de Cloud Run de `1` a `0` en `pulumi/index.ts` (función `makeCloudRun`). Con esto cada servicio puede escalar a cero cuando está inactivo, eliminando el costo de mantener una instancia siempre encendida por servicio.

Trade-off: la primera petición tras un periodo de inactividad pagará un cold-start. Se considera aceptable para el entorno actual.

No se modifica el `minInstances: 2` del VPC connector — ese recurso es necesario para que cualquier servicio que despierte pueda alcanzar Memorystore.

## Tipo de cambio
- [ ] Nueva funcionalidad
- [ ] Corrección de error
- [ ] Refactor
- [ ] Documentación
- [x] Infraestructura / configuración

## Cómo probar
- [ ] `pulumi preview` muestra el cambio de `minInstanceCount: 1 → 0` en los 9 servicios de Cloud Run y ningún otro recurso afectado.
- [ ] Tras `pulumi up`, verificar en la consola de GCP que cada servicio `travelhub-*` tiene Min instances = 0.
- [ ] Confirmar que tras inactividad el primer request a un endpoint (p. ej. `/health` vía api-gateway) responde correctamente (con cold-start).

## Issues relacionados
N/A

## Checklist
- [x] El código compila sin errores
- [ ] Se añadieron o actualizaron las pruebas correspondientes
- [ ] Se ejecutaron las pruebas existentes sin regresiones (`pnpm test`)
- [ ] El linter no reporta errores (`pnpm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)